### PR TITLE
Use a check mark instead of true/false for readability

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -235,13 +235,13 @@ Below is a list of verbs that Microsoft REST services SHOULD support. Not all re
 
 Verb    | Description                                                                                                                | Is Idempotent
 ------- | -------------------------------------------------------------------------------------------------------------------------- | -------------
-GET     | Return the current value of an object                                                                                      | True
-PUT     | Replace an object, or create a named object, when applicable                                                               | True
-DELETE  | Delete an object                                                                                                           | True
-POST    | Create a new object based on the data provided, or submit a command                                                        | False
-HEAD    | Return metadata of an object for a GET response. Resources that support the GET method MAY support the HEAD method as well | True
-PATCH   | Apply a partial update to an object                                                                                        | False
-OPTIONS | Get information about a request; see below for details.                                                                    | True
+GET     | Return the current value of an object                                                                                      | ✔
+PUT     | Replace an object, or create a named object, when applicable                                                               | ✔
+DELETE  | Delete an object                                                                                                           | ✔
+POST    | Create a new object based on the data provided, or submit a command                                                        |
+HEAD    | Return metadata of an object for a GET response. Resources that support the GET method MAY support the HEAD method as well | ✔
+PATCH   | Apply a partial update to an object                                                                                        |
+OPTIONS | Get information about a request; see below for details.                                                                    | ✔
 
 <small>Table 1</small>
 


### PR DESCRIPTION
I find that the interleaving of the work "False" with "True" makes it more difficult to read the **Is Idempotent** column than is necessary. In this review, I updated the table to use a check mark instead of "True", and simply omit the word "False".
