### PR TITLE
Add a data model for error responses

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -392,6 +392,31 @@ Error responses MAY contain [annotations][odata-json-annotations] in any of thei
 
 We recommend that for any transient errors that may be retried, services SHOULD include a Retry-After HTTP header indicating the minimum number of seconds that clients SHOULD wait before attempting the operation again.
 
+##### ErrorResponse : Object
+
+Property | Type | Required | Description
+-------- | ---- | -------- | -----------
+`error` | Error | ✔ | The error object.
+
+##### Error : Object
+
+Property | Type | Required | Description
+-------- | ---- | -------- | -----------
+`code` | String (enumerated) | ✔ | One of a server-defined set of error codes.
+`message` | String | ✔ | A human-readable representation of the error.
+`target` | String |  | The target of the error.
+`details` | Error[] |  | An array of details about specific errors that led to this reported error.
+`innererror` | InnerError |  | An object containing more specific information than the current object about the error.
+
+##### InnerError : Object
+
+Property | Type | Required | Description
+-------- | ---- | -------- | -----------
+`code` | String |  | A more specific error code than was provided by the containing error.
+`innererror` | InnerError |  | An object containing more specific information than the current object about the error.
+
+##### Examples
+
 Example of "innererror":
 
 ```json


### PR DESCRIPTION
The data model for error responses is currently described in text along with a couple of concrete examples. However, there is no explicit data model defined in terms of objects and their allowed properties. I have implemented one possible approach for defining data models and applied it to §7.10.2.

> :bulb: This data model is intended to supplement the existing descriptive language.

This form can be modified as necessary to meet the needs of this document. For example, in a similar document at work we have a **Default** column instead of **Required**, and indicate required items by the lack of a default value. I avoided that approach here because I wasn't sure what the default values would be, or if that approach would even apply to all examples in this documentation.