### PR TITLE
Fix typo in SLRO section

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1134,7 +1134,7 @@ Services MAY enable PUT requests for entity creation.
 PUT https://api.contoso.com/v1.0/databases/db1
 ```
 
-In this scenario the _databases_ segment is processing the PUT operation.
+In this scenario the _operations_ segment is processing the PUT operation.
 
 ```http
 HTTP/1.1 202 Accepted


### PR DESCRIPTION
Compare with the text in the RELO section 13.1:

> In this scenario the databases segment is processing the PUT operation.

It seems clear that the SLRO section should say `operations` here:

> In this scenario the _databases_ segment is processing the PUT operation.