### PR TITLE
Webhook backoff and retry behavior

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1717,7 +1717,7 @@ Applications MUST be prepared to receive multiple events inside a single push no
 
 The service MUST send all Web Hook data notifications as POST requests.
 
-Services MUST allow for a 30-second timeout for notifications. 
+Services MUST allow for a 30-second request timeout for notifications for the initial subscription verification callback and then 10 secs for subsequent, regular notifications. 
 If a timeout occurs or the application responds with a 5xx response, then the service SHOULD retry the notification.
 The retries SHOULD be done using exponential backoff, where the first retry occurs after 1 minute, and subsequent retries should double the interval each time.
 A service should retry a maximum of 10 times. 
@@ -1727,8 +1727,8 @@ New notification events, for the same recipient, that occur during this retry pe
 
 If the response contains a Retry-After header that is greater than interval determined by the backoff algorithm, then the Retry-After value SHOULD be respected. 
 
-A service MAY allow a 410 response to allow clients to request unsubscription.
-The service MUST NOT follow 301/302 redirect requests.
+If a service enables clients to unsubscribe from a webhook by returning a status code, it SHOULD use 410 to achieve this.
+The service MUST NOT follow 3XX redirect requests.
 
 #### 14.6.1 Notification payload
 The basic format for notification payloads is a list of events, each containing the id of the subscription whose referenced resources have changed, the type of change, the resource that should be consumed to identify the exact details of the change and sufficient identity information to look up the token required to call that resource.

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1522,7 +1522,17 @@ Notifications MAY be aggregated and sent in batches. Applications MUST be prepar
 
 The service MUST send all Web Hook data notifications as POST requests.
 
-Services MUST allow for a 30-second timeout for notifications. If a timeout occurs or the application responds with a 5xx response, then the service SHOULD retry the notification with exponential back-off. All other responses will be ignored.  
+Services MUST allow for a 30-second timeout for notifications. 
+If a timeout occurs or the application responds with a 5xx response, then the service SHOULD retry the notification.
+The retries SHOULD be done using exponential backoff, where the first retry occurs after 1 minute, and subsequent retries should double the interval each time.
+A service should retry a maximum of 10 times. 
+This backoff algorithm will cause the last retry to be after an interval of approximately 8.5 hours, with a total elapsed time of approximately 17 hours. 
+
+New notification events, for the same recipient, that occur during this retry period SHOULD be aggregated into a single notification.
+
+If the response contains a Retry-After header that is greater than interval determined by the backoff algorithm, then the Retry-After value SHOULD be respected. 
+
+A service MAY allow a 410 response to allow clients to request unsubscription.   
 
 The service MUST NOT follow 301/302 redirect requests.
 


### PR DESCRIPTION
This commit attempts to include guidance to developers implementing web hook sending behavior.  Specifically it provides what I believe to be common-sense retry intervals that should be appropriate for most cases.

The values defined were determined after reviewing the webhook documentation of a number of public APIs.  I saw total retry periods ranging from as little as 5 minutes from Pusher, to more than 12 days from Marqueta. Some APIs used constant intervals, others used linearly increasing, others exponential.  In order to account for minor network glitches and still provide a reasonably large total retry period, I believe that using an exponential approach is the most appropriate.

The initial retry period of 1 minute was chosen because it was twice the timeout period and it allows the interval to be easily calculated as 2^(# of retries) minutes.  This means only the retry count needs to be maintained between requests.  Retry count is needed anyway to stop at the max of 10.

I stopped at 10 because it was a nice round number :-) and it provided a total elapsed of 17 hours.  If a service is down for more than 17 hours, not receiving a notification is probably the least of its concerns.

I added the clause about respecting the retry-after header because if a server is going through some upgrade process that it knows will take 10 minutes and makes the effort to tell people in the retry-after header, it seems pointless to call it at 1, 2 and 4 minutes.
