### PR TITLE
Update table to match new markdown

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1,11 +1,11 @@
 # Microsoft REST API Guidelines
 ## Microsoft REST API Guidelines Working Group
 
- | | |
----------------------------- | -------------------------------------- | ----------------------------------------
-Dave Campbell (CTO C+E)      | Rick Rashid (CTO ASG)                  | John Shewchuk (Technical Fellow, TED HQ)
-Mark Russinovich (CTO Azure) | Steve Lucco (Technical Fellow, DevDiv) | Murali Krishnaprasad (Azure App Plat)
-Rob Howard (ASG)             | Peter Torr  (OSG)                      | Chris Mullins (ASG)
+|                              |                                        |                                          |
+|:-----------------------------|:---------------------------------------|:-----------------------------------------|
+| Dave Campbell (CTO C+E)      | Rick Rashid (CTO ASG)                  | John Shewchuk (Technical Fellow, TED HQ) |
+| Mark Russinovich (CTO Azure) | Steve Lucco (Technical Fellow, DevDiv) | Murali Krishnaprasad (Azure App Plat)    |
+| Rob Howard (ASG)             | Peter Torr  (OSG)                      | Chris Mullins (ASG)                      |
 
 <div style="font-size:150%">
 Document editors: John Gossman (C+E), Chris Mullins (ASG), Gareth Jones (ASG), Rob Dolin (C+E), Mark Stafford (C+E)<br/>
@@ -862,18 +862,18 @@ Services MUST use the following operator precedence for supported operators when
 Operators are listed by category in order of precedence from highest to lowest.
 Operators in the same category have equal precedence:
 
-Group           | Operator | Description
---------------- | -------- | ---------------------
-Grouping        | ( )      | Precedence grouping
-Unary           | not      | Logical Negation
-Relational      | gt       | Greater Than
-                | ge       | Greater than or Equal
-                | lt       | Less Than
-                | le       | Less than or Equal
-Equality        | eq       | Equal
-                | ne       | Not Equal
-Conditional AND | and      | Logical And
-Conditional OR  | or       | Logical Or
+| Group           | Operator | Description           |
+|:----------------|:---------|:----------------------|
+| Grouping        | ( )      | Precedence grouping   |
+| Unary           | not      | Logical Negation      |
+| Relational      | gt       | Greater Than          |
+|                 | ge       | Greater than or Equal |
+|                 | lt       | Less Than             |
+|                 | le       | Less than or Equal    |
+| Equality        | eq       | Equal                 |
+|                 | ne       | Not Equal             |
+| Conditional AND | and      | Logical And           |
+| Conditional OR  | or       | Logical Or            |
 
 ### 9.8 Pagination
 RESTful APIs that return collections MAY return partial sets.
@@ -1220,17 +1220,17 @@ The Group Version format is defined as YYYY-MM-DD, for example 2012-12-07 for De
 
 ##### 12.1.1.1 Examples of group versioning
 
-Group      | Major.Minor
----------- | -----------
-2012-12-01 | 1.0
-           | 1.1
-           | 1.2
-2013-03-21 | 1.0
-           | 2.0
-           | 3.0
-           | 3.1
-           | 3.2
-           | 3.3
+| Group      | Major.Minor |
+|:-----------|:------------|
+| 2012-12-01 | 1.0         |
+|            | 1.1         |
+|            | 1.2         |
+| 2013-03-21 | 1.0         |
+|            | 2.0         |
+|            | 3.0         |
+|            | 3.1         |
+|            | 3.2         |
+|            | 3.3         |
 
 Version Format                | Example                | Interpretation
 ----------------------------- | ---------------------- | ------------------------------------------


### PR DESCRIPTION
Some tables got eaten by new [markdown rules](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown), updates table with new markdown and aligns.

| Before | After|
|--|--|
| ![screen shot 2017-03-31 at 10 55 38 am](https://cloud.githubusercontent.com/assets/6805534/24555984/f6564050-1600-11e7-9213-839af9401f67.png) | ![screen shot 2017-03-31 at 10 57 49 am](https://cloud.githubusercontent.com/assets/6805534/24556001/fca0bb8e-1600-11e7-8edc-9560e1b5d499.png) |
| ![screen shot 2017-03-31 at 10 55 54 am](https://cloud.githubusercontent.com/assets/6805534/24556038/150e6b76-1601-11e7-96da-3c4d6f533d6c.png) | ![screen shot 2017-03-31 at 10 57 40 am](https://cloud.githubusercontent.com/assets/6805534/24556055/228226c6-1601-11e7-8055-2f6b8f0eccc9.png) |
| ![screen shot 2017-03-31 at 10 56 01 am](https://cloud.githubusercontent.com/assets/6805534/24556069/29eaaa14-1601-11e7-9906-c7b9de814cb6.png) | ![screen shot 2017-03-31 at 10 57 55 am](https://cloud.githubusercontent.com/assets/6805534/24556074/2de5ddbe-1601-11e7-990c-cc7d832055d6.png)|




