### PR TITLE
macOS instead of MacOS

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -583,7 +583,7 @@ In this example there were multiple problems with the request, with each individ
 Standard HTTP Status Codes SHOULD be used; see the HTTP Status Code definitions for more information.
 
 ### 7.12 Client library optional
-Developers MUST be able to develop on a wide variety of platforms and languages, such as Windows, MacOS, Linux, C#, Python, Node.js, and Ruby.
+Developers MUST be able to develop on a wide variety of platforms and languages, such as Windows, macOS, Linux, C#, Python, Node.js, and Ruby.
 
 Services SHOULD be able to be accessed from simple HTTP tools such as curl without significant effort.
 


### PR DESCRIPTION
Since June 13, 2016 the name of the Apple's operating system has been changed to macOS. Both OS X and MacOS should considered wrong.

The Guidelines used to contain MacOS. This PR fixes the name to macOS.

(Yes, actually this is a pull request for 1 single modified character)