### PR TITLE
Move commas outside double quotes

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -320,7 +320,7 @@ Microsoft REST API Guidelines compliant APIs SHOULD support PATCH.
 #### 7.4.3 Creating resources via PATCH (UPSERT semantics)
 Services that allow callers to specify key values on create SHOULD support UPSERT semantics, and those that do MUST support creating resources using PATCH.
 Because PUT is defined as a complete replacement of the content, it is dangerous for clients to use PUT to modify data.
-Clients that do not understand (and hence ignore) properties on a resource are not likely to provide them on a PUT when trying to update a resource, hence such properties MAY be inadvertently removed.
+Clients that do not understand (and hence ignore) properties on a resource are not likely to provide them on a PUT when trying to update a resource, hence such properties could be inadvertently removed.
 Services MAY optionally support PUT to update existing resources, but if they do they MUST use replacement semantics (that is, after the PUT, the resource's properties MUST match what was provided in the request, including deleting any server properties that were not provided).
 
 Under UPSERT semantics, a PATCH call to a nonexistent resource is handled by the server as a "create," and a PATCH call to an existing resource is handled as an "update." To ensure that an update request is not treated as a create or vice-versa, the client MAY specify precondition HTTP headers in the request.

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1,7 +1,7 @@
 # Microsoft REST API Guidelines
 ## Microsoft REST API Guidelines Working Group
 
- | | |
+Name | Name | Name |
 ---------------------------- | -------------------------------------- | ----------------------------------------
 Dave Campbell (CTO C+E)      | Rick Rashid (CTO ASG)                  | John Shewchuk (Technical Fellow, TED HQ)
 Mark Russinovich (CTO Azure) | Steve Lucco (Technical Fellow, DevDiv) | Murali Krishnaprasad (Azure App Plat)

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -160,7 +160,7 @@ When a service adds a new API, that API SHOULD be consistent with the other APIs
 So if a service was written against version 1.0 of the guidelines, new APIs added incrementally to the service SHOULD also follow version 1.0. The service can then upgrade to align with the latest version of the guidelines at the service's next major release.
 
 ### 4.3 Requirements language
-The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD," "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt). 
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ### 4.4 License
 


### PR DESCRIPTION
The section "4.3 Requirements language" contains a list of keywords, in double quotes. The commas separating the items were wrongly inside the double quotes, like the following:

    The keywords "MUST," "MUST NOT,"

This pull request just fixes this, replacing the above with

    The keywords "MUST", "MUST NOT",