### PR TITLE
Fixed typo in Guidelines.md

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -2103,7 +2103,7 @@ All sequence diagrams in this document are generated using the WebSequenceDiagra
 #### 17.1.1 Push notifications, per user flow
 
 ```
-=== Being Text ===
+=== Begin Text ===
 note over Developer, Automation, App Server:
      An App Developer like MovieMaker
      Wants to integrate with primary service like Dropbox
@@ -2158,7 +2158,7 @@ note right of App Server: Update status and cache new "since" token
 #### 17.1.2 Push notifications, firehose flow
 
 ```
-=== Being Text ===
+=== Begin Text ===
 note over Developer, Automation, App Server:
      An App Developer like MovieMaker
      Wants to integrate with primary service like Dropbox


### PR DESCRIPTION
Fixed typo: "Being text" => "Begin text" .  It had a matching "End text", so it was definitely meant to say Begin rather than Being