### PR TITLE
Minor Typographical Fix

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -15,7 +15,7 @@ Document editors: John Gossman (C+E), Chris Mullins (ASG), Gareth Jones (ASG), R
 # Microsoft REST API Guidelines
 
 ## 1. Abstract
-The Microsoft REST API Guidelines, as a design principle, encourages application developers to have resources accessible to them via a RESTful HTTP interface.
+The Microsoft REST API Guidelines, as a design principle, encourage application developers to have resources accessible to them via a RESTful HTTP interface.
 To provide the smoothest possible experience for developers on platforms following the Microsoft REST API Guidelines, REST APIs SHOULD follow consistent design guidelines to make using them easy and intuitive.
 
 This document establishes the guidelines Microsoft REST APIs SHOULD follow so RESTful interfaces are developed consistently.


### PR DESCRIPTION
As **guidelines** and not a singular **guideline**, it should be plural to encompass all of them and not be limited to a single one. I'm sorry but it struck my eye while going through them so I decided to send a fix.