### PR TITLE
Add link to redirect to the WebSequenceDiagrams web site

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -2242,7 +2242,7 @@ Service owners adding such terms SHOULD propose additions to this document.
 
 ## 18. Appendix
 ### 18.1. Sequence diagram notes
-All sequence diagrams in this document are generated using the WebSequenceDiagrams.com web site. To generate them, paste the text below into the web tool.
+All sequence diagrams in this document are generated using the [WebSequenceDiagrams.com](https://www.websequencediagrams.com/) web site. To generate them, paste the text below into the web tool.
 
 #### 18.1.1. Push notifications, per user flow
 

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -2242,7 +2242,7 @@ Service owners adding such terms SHOULD propose additions to this document.
 
 ## 18. Appendix
 ### 18.1. Sequence diagram notes
-All sequence diagrams in this document are generated using the [WebSequenceDiagrams.com](https://www.websequencediagrams.com/) web site. To generate them, paste the text below into the web tool.
+All sequence diagrams in this document are generated using the [WebSequenceDiagrams.com](https://www.websequencediagrams.com/). To generate them, paste the text below into the web tool.
 
 #### 18.1.1. Push notifications, per user flow
 


### PR DESCRIPTION
It was missing the link to redirect to this site, so if the user wanted to check it out, he needed to copy the link e paste into the url to see it.