### PR TITLE
Polling on operation status to terminal state instead of 200 response

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1541,7 +1541,7 @@ Services MAY choose to delete tombstones after a service defined period of time.
 #### 13.2.7. The typical flow, polling
 - Client invokes a stepwise operation by invoking an action using POST
 - The server MUST indicate the request has been started by responding with a 202 Accepted status code. The response SHOULD include the location header containing a URL that the client should poll for the results after waiting the number of seconds specified in the Retry-After header.
-- Client polls the location until receiving a 200 OK response from the server.
+- Client polls the location until receiving a 200 response with a terminal operation state. 
 
 ##### Example of the typical flow, polling
 Client invokes the restart action:


### PR DESCRIPTION
@darrelmiller pointed out that Section 13.2.7. "The typical flow, polling" is unclear. The description says to poll on operations resource until a 200 response is received (which I believe is incorrect)

The example continues polling until a 200 response with a terminal status is received (which I believe is correct).