### PR TITLE
Provide note for 64bit integers

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1096,7 +1096,9 @@ If the delta link is no longer valid, the service MUST respond with _410 Gone_. 
 
 ## 11. JSON standardizations
 ### 11.1. JSON formatting standardization for primitive types
-Primitive values MUST be serialized to JSON following the rules of [RFC4627][rfc-4627].
+Primitive values MUST be serialized to JSON following the rules of [RFC4627][rfc-4627]. 
+
+**Important note for 64bit integers:** JavaScript will silently truncate integers larger than `Number.MAX_SIZE_INTEGER` (2^53-1). If the service is expected to return larger integer values, consider returning the value as a string. 
 
 ### 11.2. Guidelines for dates and times
 #### 11.2.1. Producing dates

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1096,9 +1096,9 @@ If the delta link is no longer valid, the service MUST respond with _410 Gone_. 
 
 ## 11. JSON standardizations
 ### 11.1. JSON formatting standardization for primitive types
-Primitive values MUST be serialized to JSON following the rules of [RFC4627][rfc-4627]. 
+Primitive values MUST be serialized to JSON following the rules of [RFC8259][rfc-8259]. 
 
-**Important note for 64bit integers:** JavaScript will silently truncate integers larger than `Number.MAX_SIZE_INTEGER` (2^53-1). If the service is expected to return larger integer values, consider returning the value as a string. 
+**Important note for 64bit integers:** JavaScript will silently truncate integers larger than `Number.MAX_SAFE_INTEGER` (2^53-1) or numbers smaller than `Number.MIN_SAFE_INTEGER` (-2^53+1). If the service is expected to return integer values outside the range of safe values, strongly consider returning the value as a string in order to maximize interoperability adn avoid data loss.
 
 ### 11.2. Guidelines for dates and times
 #### 11.2.1. Producing dates
@@ -1659,7 +1659,7 @@ Operation-Location: http://api.contoso.com/v1.0/operations/123
 Retry-After: 60
 ```
 
-Note: The use of the HTTP Date is inconsistent with the use of ISO 8601 Date Format used throughout this document, but is explicitly defined by the HTTP standard in [RFC 7231][rfc-7231-7-1-1-1]. Services SHOULD prefer the integer number of seconds (in decimal) format over the HTTP date format.
+Note: The use of the HTTP Date is inconsistent with the use of ISO 8601 Date Format used throughout this document, but is explicitly defined by the HTTP standard in [7231][rfc-7231-7-1-1-1]. Services SHOULD prefer the integer number of seconds (in decimal) format over the HTTP date format.
 
 ### 13.3. Retention policy for operation results
 In some situations, the result of a long running operation is not a resource that can be addressed.

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -195,7 +195,7 @@ If you are new to RESTful design, here are some good resources:
 
 [REST Dissertation][fielding] -- The chapter on REST in Roy Fielding's dissertation on Network Architecture, "Architectural Styles and the Design of Network-based Software Architectures"
 
-[RFC 7231][rfc-7231] -- Defines the specification for HTTP/1.1 semantics, and is considered the authoritative resource.
+[RFC 7231][rfc-] -- Defines the specification for HTTP/1.1 semantics, and is considered the authoritative resource.
 
 [REST in Practice][rest-in-practice] -- Book on the fundamentals of REST.
 
@@ -1659,7 +1659,7 @@ Operation-Location: http://api.contoso.com/v1.0/operations/123
 Retry-After: 60
 ```
 
-Note: The use of the HTTP Date is inconsistent with the use of ISO 8601 Date Format used throughout this document, but is explicitly defined by the HTTP standard in [7231][rfc-7231-7-1-1-1]. Services SHOULD prefer the integer number of seconds (in decimal) format over the HTTP date format.
+Note: The use of the HTTP Date is inconsistent with the use of ISO 8601 Date Format used throughout this document, but is explicitly defined by the HTTP standard in [RFC 7231][rfc-7231-7-1-1-1]. Services SHOULD prefer the integer number of seconds (in decimal) format over the HTTP date format.
 
 ### 13.3. Retention policy for operation results
 In some situations, the result of a long running operation is not a resource that can be addressed.

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -195,7 +195,7 @@ If you are new to RESTful design, here are some good resources:
 
 [REST Dissertation][fielding] -- The chapter on REST in Roy Fielding's dissertation on Network Architecture, "Architectural Styles and the Design of Network-based Software Architectures"
 
-[RFC 7231][rfc-] -- Defines the specification for HTTP/1.1 semantics, and is considered the authoritative resource.
+[RFC 7231][rfc-7231] -- Defines the specification for HTTP/1.1 semantics, and is considered the authoritative resource.
 
 [REST in Practice][rest-in-practice] -- Book on the fundamentals of REST.
 


### PR DESCRIPTION
JSON payloads containing numbers larger than JavaScripts Number.MAX_SAFE_INTEGER can cause silent truncation for JavaScript clients. Added blurb to suggest that services avoid this scenario.