### PR TITLE
Fix breaking changes link

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -5,7 +5,7 @@ Designing powerful APIs with strong defaults, consistent behavior across related
 * [Considerations for Service Design](ConsiderationsForServiceDesign.md)
 * [REST API Guidelines](Guidelines.md)
 * [OpenAPI Style Guidelines](https://github.com/Azure/azure-api-style-guide/blob/main/README.md)
-* [Breaking Changes](https://aka.ms/azapi/breakingchanges)
+* [Breaking Changes](http://aka.ms/AzBreakingChangesPolicy/)
 
 You can reach out to use via [email](mailto://azureapirbcore@microsoft.com) or in our [Teams](https://teams.microsoft.com/l/team/19%3a3ebb18fded0e47938f998e196a52952f%40thread.tacv2/conversations?groupId=1a10b50c-e870-4fe0-8483-bf5542a8d2d8&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) channel.
 


### PR DESCRIPTION
Use the correct shortlink for the "current" version of the Azure Breaking Changes policy doc.

The previous link went to version 1.2, but the current version is 1.2.1.