### PR TITLE
Add guidance for count field in pageable response

### DIFF
--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -506,7 +506,9 @@ Note: To avoid potential collision of actions and resource ids, you should disal
 
 :no_entry: **DO NOT** return the `nextLink` field at all when returning the last page of the collection.
 
-:no_entry: **DO NOT** ever return a `nextLink` field with a value of null.
+:no_entry: **DO NOT** return the `nextLink` field with a value of null.
+
+:warning: **YOU SHOULD NOT** return a `count` of all objects in the collection as this may be expensive to compute.
 
 #### Query options
 :heavy_check_mark: **YOU MAY** support the following query parameters allowing customers to control the list operation:


### PR DESCRIPTION
This PR adds one small bit of guidance that we commonly give to service teams -- don't include a `count` field in a pageable response since this could be expensive to compute.

I made this a "You should not" since a `count` field could be allowed when needed to support a specific use case.