### PR TITLE
Reorder the guidelines so the error contract is clearer

### DIFF
--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -302,8 +302,6 @@ There are 2 kinds of errors:
 
 :white_check_mark: **DO** ensure that the top-level error's `code` value is identical to the `x-ms-error-code` header's value.
 
-:white_check_mark: **DO** document the service's error code strings; they are part of the API contract.
-
 :white_check_mark: **DO** provide a response body with the following structure:
 
 **ErrorResponse** : Object
@@ -346,6 +344,8 @@ Example:
 ```
 
 :heavy_check_mark: **YOU MAY** group common customer code errors into a few `x-ms-error-code` string values.
+
+:white_check_mark: **DO** document the service's top-level error code strings; they are part of the API contract.
 
 :heavy_check_mark: **YOU MAY** treat the other fields as you wish as they are _not_ considered part of your service's API contract and customers should not take a dependency on them or their value. They exist to help customers self-diagnose issues.
 

--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -300,6 +300,8 @@ There are 2 kinds of errors:
 
 :white_check_mark: **DO** carefully craft unique `x-ms-error-code` string values for errors that are recoverable at runtime.  Reuse common error codes for usage errors that are not recoverable.
 
+:heavy_check_mark: **YOU MAY** group common customer code errors into a few `x-ms-error-code` string values.
+
 :white_check_mark: **DO** ensure that the top-level error's `code` value is identical to the `x-ms-error-code` header's value.
 
 :white_check_mark: **DO** provide a response body with the following structure:
@@ -342,8 +344,6 @@ Example:
   }
 }
 ```
-
-:heavy_check_mark: **YOU MAY** group common customer code errors into a few `x-ms-error-code` string values.
 
 :white_check_mark: **DO** document the service's top-level error code strings; they are part of the API contract.
 


### PR DESCRIPTION
There's a gap between the two rules talking about what's part of the error contract and what isn't.  I think this makes it easier for teams to understand.