### PR TITLE
Update Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These are the set of folks who should review PRs on the azureRestUpdates branch.
-* @microsoft/azure-api-stewardship-board
+* @microsoft/azure-api-stewardship-board @Azure/api-stewardship-board


### PR DESCRIPTION
Find out we actually already had `@microsoft/azure-api-stewardship-board` github team.

Please give either `@microsoft/azure-api-stewardship-board` or `@Azure/api-stewardship-board` write permission to the repository, for code owner assignment to team.

> The people you choose as code owners must have read permissions for the repository. When the code owner is a team, that team must be visible and it must have write permissions, even if all the individual members of the team already have write permissions directly, through organization membership, or through another team membership.

Or instead we can add individuals as code owner.