### PR TITLE
Add Alternate Key Pattern

### DIFF
--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -19,7 +19,7 @@ While it is still possible to use the oData filter, such as
 ## Solution
 --------
 
-oData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
+oData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key attribute name to unambiguously determine the alternate key.
 
 https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`
@@ -34,7 +34,7 @@ In such case, we **strongly** advice to throw an exception and encourage the use
 ## Example
 -------
 
-The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key property name, and the canonical short form without key property name
+The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key attribute name, and the canonical short form without key attribute name
 
 https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -29,12 +29,7 @@ https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the em
 
 ---
 
-This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client; while it does not work if the resultset has more than one element.
-
-In such case, the workload has two choices:
-
-1. If the workload defines a list of alternate keys for a resource and the requested key is not there, the workload SHOULD return `422`
-2. If the workload does not have a list of alternate keys, it can still query the data source, but if the result yields more than a record, it SHOULD return `422` and encourage the user to use `$filter` rather than returning the first result of the query
+This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client; while it does not work if the resultset has more than one element. In such case, the workload SHOULD return `400`
 
 ## Example
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -31,7 +31,7 @@ https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the em
 
 This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client; while it does not work if the resultset has more than one element.
 
-In such case, we **strongly** advice to throw an exception and encourage the user to use `$filter` rather than returning the first result of the query
+In such case, the system SHOULD throw an exception and encourage the user to use `$filter` rather than returning the first result of the query
 
 ## Example
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -2,14 +2,14 @@
 
 Microsoft Graph API Design Pattern
 
-*The Alternate Key Pattern provides the ability to query for a single, specific entity identifiable through an alternative attribute (called key) that is not its unique identifier*
+*The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative attribute (called key) that is not its unique identifier*
 
 ## Problem
 --------
 
-All entities in our system are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness. Often though, that same entity can also be uniquely identified by an alternative, more convenient attribute.
+All entities in our system are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness. Often though, that same resource can also be uniquely identified by an alternative, more convenient attribute.
 
-Take a look at the `user` entity: while the `id` remains a perfectly valid way to get the entity details, the `mail` address is also an unique attribute that could be used to identify it.
+Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique attribute that could be used to identify it.
 
 While it is still possible to use the oData filter, such as
 
@@ -19,7 +19,7 @@ While it is still possible to use the oData filter, such as
 ## Solution
 --------
 
-oData offers entity addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
+oData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
 
 https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`
@@ -27,7 +27,7 @@ https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the em
 ## When to Use this Pattern
 ------------------------
 
-This pattern works and makes sense when the alternate key is good enough to identify a single entity and provides an useful alternative to the client; while it does not work if the resultset has more than one element.
+This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client; while it does not work if the resultset has more than one element.
 
 In such case, we **strongly** advice to throw an exception and encourage the user to use `$filter` rather than returning the first result of the query 
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -21,8 +21,8 @@ While it is still possible to use the oData filter, such as
 
 oData offers entity addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
 
-http://host/service/Employees(0) - Retrieves the employee with ID = 0
-http://host/service/Employees(email='hello@microsoft.com') Retrieves the employee with the email matching `hello@microsoft.com`
+https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
+https://graph.microsoft.com/v1.0/users(email='hello@microsoft.com') Retrieves the employee with the email matching `hello@microsoft.com`
 
 ## When to Use this Pattern
 ------------------------
@@ -36,11 +36,11 @@ In such case, we **strongly** advice to throw an exception and encourage the use
 
 The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key property name, and the canonical short form without key property name
 
-http://host/service/Employees/1a89ade6-9f59-4fea-a139-23f84e3aef66
+https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 
-http://host/service/Employees(ssn='123-45-6789')
+https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
 
-http://host/service/Employees(email='hello@microsoft.com')
+https://graph.microsoft.com/v1.0/users(email='hello@microsoft.com')
 
 
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -2,15 +2,15 @@
 
 Microsoft Graph API Design Pattern
 
-_The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative attribute (called key) that is not its unique identifier_
+_The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative property (called key) that is not its unique identifier_
 
 ## Problem
 
 ---
 
-The resources exposed in Graph are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness inside the same resource type. Often though, that same resource can also be uniquely identified by an alternative, more convenient attribute that provides a better developer experience.
+The resources exposed in Graph are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness inside the same resource type. Often though, that same resource can also be uniquely identified by an alternative, more convenient property that provides a better developer experience.
 
-Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique attribute that could be used to identify it.
+Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique property that could be used to identify it.
 
 While it is still possible to use the oData filter, such as
 
@@ -20,7 +20,7 @@ While it is still possible to use the oData filter, such as
 
 ---
 
-oData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key attribute name to unambiguously determine the alternate key.
+oData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
 
 https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`
@@ -37,7 +37,7 @@ In such case, the system SHOULD throw an exception and encourage the user to use
 
 ---
 
-The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key attribute name, and the canonical short form without key attribute name
+The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key property name, and the canonical short form without key property name
 
 https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -9,7 +9,7 @@ Microsoft Graph API Design Pattern
 
 All entities in our system are identified by an UUID - which guarantees uniqueness. Often though, that same entity can also be uniquely identified by an alternative, more convenient attribute.
 
-Take a look at the `user` entity: while the UUID remains a perfectly valid way to get the entity details, the `mail` address is also an unique attribute that could be used to identify it.
+Take a look at the `user` entity: while the `id` remains a perfectly valid way to get the entity details, the `mail` address is also an unique attribute that could be used to identify it.
 
 While it is still possible to use the oData filter, such as
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -9,7 +9,7 @@ Microsoft Graph API Design Pattern
 
 All entities in our system are identified by an UUID - which guarantees uniqueness. Often though, that same entity can also be uniquely identified by an alternative, more convenient attribute.
 
-Take a look at the `user` entity: while the UUID remains a perfectly valid way to get the entity details, the `email` address is also an unique attribute that could be used to identify it.
+Take a look at the `user` entity: while the UUID remains a perfectly valid way to get the entity details, the `mail` address is also an unique attribute that could be used to identify it.
 
 While it is still possible to use the oData filter, such as
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -14,7 +14,7 @@ Take a look at the `user` resource: while the `id` remains a perfectly valid way
 
 While it is still possible to use the oData filter, such as
 
-`https://graph.microsoft.com/v1.0/users?filter=mail eq 'bob@contoso.com'`, the returned result is wrapped in an array that needs to be unpacked.
+`https://graph.microsoft.com/v1.0/users?$filter=mail eq 'bob@contoso.com'`, the returned result is wrapped in an array that needs to be unpacked.
 
 ## Solution
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -2,13 +2,13 @@
 
 Microsoft Graph API Design Pattern
 
-_The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative property (called key) that is not its unique identifier_
+_The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative property (called key) that is not its primary key_
 
 ## Problem
 
 ---
 
-The resources exposed in Graph are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness inside the same resource type. Often though, that same resource can also be uniquely identified by an alternative, more convenient property that provides a better developer experience.
+The resources exposed in Graph are identified through a Primary Key - which guarantees uniqueness inside the same resource type. Often though, that same resource can also be uniquely identified by an alternative, more convenient property (or set of properties) that provides a better developer experience.
 
 Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique property that could be used to identify it.
 
@@ -102,7 +102,7 @@ GET https://graph.microsoft.com/v1.0/users/?$filter=(ssn eq '123-45-6789')
 }
 ```
 
-2. Get a specific resource through the unique identifier, and then through the two alternate keys:
+2. Get a specific resource through its primary key, and then through the two alternate keys:
 
 ```http
 GET https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -7,7 +7,7 @@ Microsoft Graph API Design Pattern
 ## Problem
 --------
 
-All entities in our system are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness. Often though, that same resource can also be uniquely identified by an alternative, more convenient attribute.
+All entities in our system are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness. Often though, that same resource can also be uniquely identified by an alternative, more convenient attribute that provides a better developer experience.
 
 Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique attribute that could be used to identify it.
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -102,7 +102,7 @@ GET https://graph.microsoft.com/v1.0/users/?$filter=ssn eq '123-45-6789'
 ```http
 GET https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 GET https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
-GET https://graph.microsoft.com/v1.0/users(email='bob@contoso.com')
+GET https://graph.microsoft.com/v1.0/users(mail='bob@contoso.com')
 ```
 
 **NOTE:** When requesting a resource through its primary key you might want to prefer to use key-as-segment (as shown above). Also, the key-as-segment does not work for alternate keys.

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -20,7 +20,7 @@ While it is still possible to use the OData filter, such as
 
 ---
 
-OData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
+OData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key. (Note: this is a hypothetical sample)
 
 https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -126,7 +126,7 @@ All of the 3 will yield the sare response:
 }
 ```
 
-3. Requesting a resource through an alternate key which yields more than a result
+3. Requesting a resource through an alternate key which yields more than one result
 
 ```http
 GET https://graph.microsoft.com/v1.0/users(name='Bob')

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -12,7 +12,7 @@ The resources exposed in Graph are identified by an [UUID (Universally Unique Id
 
 Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique property that could be used to identify it.
 
-While it is still possible to use the oData filter, such as
+While it is still possible to use the OData filter, such as
 
 `https://graph.microsoft.com/v1.0/users?$filter=mail eq 'bob@contoso.com'`, the returned result is wrapped in an array that needs to be unpacked.
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -117,6 +117,7 @@ All of the 3 will yield the sare response:
   "mobilePhone": "+1 425 555 0109",
   "officeLocation": "18/2111",
   "preferredLanguage": "en-US",
+  "ssn": "123-45-6789",
   "surname": "Vance",
   "userPrincipalName": "bob@contoso.com",
   "id": "1a89ade6-9f59-4fea-a139-23f84e3aef66"

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -95,5 +95,5 @@ All of the 3 will yield the sare response:
 ```http
 GET https://graph.microsoft.com/v1.0/users(name='Bob')
 
-422 Precondition Failed
+400 Bad Request
 ```

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -8,7 +8,7 @@ _The Alternate Key Pattern provides the ability to query for a single, specific 
 
 ---
 
-All entities in our system are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness. Often though, that same resource can also be uniquely identified by an alternative, more convenient attribute that provides a better developer experience.
+The resources exposed in Graph are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness inside the same resource type. Often though, that same resource can also be uniquely identified by an alternative, more convenient attribute that provides a better developer experience.
 
 Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique attribute that could be used to identify it.
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -1,0 +1,48 @@
+# Alternate Key Pattern
+
+Microsoft Graph API Design Pattern
+
+*The Alternate Key Pattern provides the ability to query for a single, specific entity identifiable through an alternative attribute (called key) that is not its unique identifier*
+
+## Problem
+--------
+
+All entities in our system are identified by an UUID - which guarantees uniqueness. Often though, that same entity can also be uniquely identified by an alternative, more convenient attribute.
+
+Take a look at the `user` entity: while the UUID remains a perfectly valid way to get the entity details, the `email` address is also an unique attribute that could be used to identify it.
+
+While it is still possible to use the oData filter, such as
+
+`serviceRoot/Users?$filter=email eq 'hello@microsoft.com'`, the returned result is wrapped in an array that needs to be unpacked.
+
+
+## Solution
+--------
+
+oData offers entity addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
+
+http://host/service/Employees(0) - Retrieves the employee with ID = 0
+http://host/service/Employees(email='hello@microsoft.com') Retrieves the employee with the email matching `hello@microsoft.com`
+
+## When to Use this Pattern
+------------------------
+
+This pattern works when the alternate key is good enough to identify a single entity that is properly namespaced; while it does not work if the resultset has more than one element.
+
+In such case, we **strongly** advice to throw an exception and encourage the user to use `$filter` rather than returning the first result of the query 
+
+## Example
+-------
+
+The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key property name, and the canonical short form without key property name
+
+http://host/service/Employees/1a89ade6-9f59-4fea-a139-23f84e3aef66
+
+http://host/service/Employees(ssn='123-45-6789')
+
+http://host/service/Employees(email='hello@microsoft.com')
+
+
+
+
+

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -13,7 +13,7 @@ Take a look at the `user` entity: while the UUID remains a perfectly valid way t
 
 While it is still possible to use the oData filter, such as
 
-`serviceRoot/Users?$filter=email eq 'hello@microsoft.com'`, the returned result is wrapped in an array that needs to be unpacked.
+`https://graph.microsoft.com/v1.0/users?filter=mail eq 'bob@contoso.com'`, the returned result is wrapped in an array that needs to be unpacked.
 
 
 ## Solution
@@ -22,7 +22,7 @@ While it is still possible to use the oData filter, such as
 oData offers entity addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
 
 https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
-https://graph.microsoft.com/v1.0/users(email='hello@microsoft.com') Retrieves the employee with the email matching `hello@microsoft.com`
+https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`
 
 ## When to Use this Pattern
 ------------------------
@@ -40,7 +40,7 @@ https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 
 https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
 
-https://graph.microsoft.com/v1.0/users(email='hello@microsoft.com')
+https://graph.microsoft.com/v1.0/users(email='bob@contoso.com')
 
 
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -20,7 +20,7 @@ While it is still possible to use the OData filter, such as
 
 ---
 
-oData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
+OData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key.
 
 https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -7,7 +7,7 @@ Microsoft Graph API Design Pattern
 ## Problem
 --------
 
-All entities in our system are identified by an UUID - which guarantees uniqueness. Often though, that same entity can also be uniquely identified by an alternative, more convenient attribute.
+All entities in our system are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness. Often though, that same entity can also be uniquely identified by an alternative, more convenient attribute.
 
 Take a look at the `user` entity: while the `id` remains a perfectly valid way to get the entity details, the `mail` address is also an unique attribute that could be used to identify it.
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -27,7 +27,7 @@ https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the em
 ## When to Use this Pattern
 ------------------------
 
-This pattern works when the alternate key is good enough to identify a single entity that is properly namespaced; while it does not work if the resultset has more than one element.
+This pattern works and makes sense when the alternate key is good enough to identify a single entity and provides an useful alternative to the client; while it does not work if the resultset has more than one element.
 
 In such case, we **strongly** advice to throw an exception and encourage the user to use `$filter` rather than returning the first result of the query 
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -42,6 +42,42 @@ In such case, the workload has two choices:
 
 The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key property name, and the canonical short form without key property name
 
+Declare `mail` and `ssn` as alternate keys on an entity:
+
+```xml
+<EntityType Name="User">
+   <Key>
+     <PropertyRef Name="id" />
+   </Key>
+   <Property Name="id" Type="Edm.Int32" />
+   
+   <Property Name="mail" Type="Edm.String" />
+   <Property Name="ssn" Type="Edm.String" />
+   <Annotation Term="Keys.AlternateKeys">
+      <Collection>
+         <Record>
+            <PropertyValue Property="Key">
+               <Collection>
+                  <Record>
+                     <PropertyValue Property="Name" PropertyPath="mail" />
+                  </Record>
+               </Collection>
+            </PropertyValue>
+         </Record>
+         <Record>
+            <PropertyValue Property="Key">
+               <Collection>
+                  <Record>
+                     <PropertyValue Property="Name" PropertyPath="ssn" />
+                  </Record>
+               </Collection>
+            </PropertyValue>
+         </Record>
+      </Collection>
+   </Annotation>
+</EntityType>
+```
+
 1. Get a specific resource through `$filter`:
 
 ```http

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -44,3 +44,21 @@ https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
 
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com')
+
+All of the 3 will yield the sare response:
+
+
+```json
+{
+   "givenName": "Bob",
+   "jobTitle": "Retail Manager",
+   "mail": "bob@contoso.com",
+   "mobilePhone": "+1 425 555 0109",
+   "officeLocation": "18/2111",
+   "preferredLanguage": "en-US",
+   "surname": "Vance",
+   "userPrincipalName": "bob@contoso.com",
+   "id": "1a89ade6-9f59-4fea-a139-23f84e3aef66"
+}
+```
+

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -50,7 +50,7 @@ Declare `mail` and `ssn` as alternate keys on an entity:
      <PropertyRef Name="id" />
    </Key>
    <Property Name="id" Type="Edm.Int32" />
-   
+
    <Property Name="mail" Type="Edm.String" />
    <Property Name="ssn" Type="Edm.String" />
    <Annotation Term="Keys.AlternateKeys">
@@ -102,7 +102,7 @@ GET https://graph.microsoft.com/v1.0/users/?$filter=(ssn eq '123-45-6789')
 }
 ```
 
-2. Get a specific resource through the alternate key:
+2. Get a specific resource through the unique identifier, and then through the two alternate keys:
 
 ```http
 GET https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -121,7 +121,7 @@ All of the 3 will yield the sare response:
 }
 ```
 
-3. Requesting a resource through an alternate key which yields more than one result
+3. Requesting a resource for an unsupported alternate key property
 
 ```http
 GET https://graph.microsoft.com/v1.0/users(name='Bob')

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -31,7 +31,10 @@ https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the em
 
 This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client; while it does not work if the resultset has more than one element.
 
-In such case, the system SHOULD throw an exception and encourage the user to use `$filter` rather than returning the first result of the query
+In such case, the workload has two choices:
+
+1. If the workload defines a list of alternate keys for a resource and the requested key is not there, the workload SHOULD return `422`
+2. If the workload does not have a list of alternate keys, it can still query the data source, but if the result yields more than a record, it SHOULD return `422` and encourage the user to use `$filter` rather than returning the first result of the query
 
 ## Example
 
@@ -85,4 +88,12 @@ All of the 3 will yield the sare response:
   "userPrincipalName": "bob@contoso.com",
   "id": "1a89ade6-9f59-4fea-a139-23f84e3aef66"
 }
+```
+
+3. Requesting a resource through an alternate key which yields more than a result
+
+```http
+GET https://graph.microsoft.com/v1.0/users(name='Bob')
+
+422 Precondition Failed
 ```

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -2,7 +2,7 @@
 
 Microsoft Graph API Design Pattern
 
-_The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative property (called key) that is not its primary key_
+_The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative set of properties that is not its primary key_
 
 ## Problem
 

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -39,26 +39,50 @@ In such case, the system SHOULD throw an exception and encourage the user to use
 
 The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key property name, and the canonical short form without key property name
 
-https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
+1. Get a specific resource through `$filter`:
 
-https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
-
-https://graph.microsoft.com/v1.0/users(email='bob@contoso.com')
-
-All of the 3 will yield the sare response:
-
+```http
+GET https://graph.microsoft.com/v1.0/users/?$filter=(ssn eq '123-45-6789')
+```
 
 ```json
 {
-   "givenName": "Bob",
-   "jobTitle": "Retail Manager",
-   "mail": "bob@contoso.com",
-   "mobilePhone": "+1 425 555 0109",
-   "officeLocation": "18/2111",
-   "preferredLanguage": "en-US",
-   "surname": "Vance",
-   "userPrincipalName": "bob@contoso.com",
-   "id": "1a89ade6-9f59-4fea-a139-23f84e3aef66"
+  "value": [
+    {
+      "givenName": "Bob",
+      "jobTitle": "Retail Manager",
+      "mail": "bob@contoso.com",
+      "mobilePhone": "+1 425 555 0109",
+      "officeLocation": "18/2111",
+      "preferredLanguage": "en-US",
+      "surname": "Vance",
+      "userPrincipalName": "bob@contoso.com",
+      "id": "1a89ade6-9f59-4fea-a139-23f84e3aef66"
+    }
+  ]
 }
 ```
 
+2. Get a specific resource through the alternate key:
+
+```http
+GET https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
+GET https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
+GET https://graph.microsoft.com/v1.0/users(email='bob@contoso.com')
+```
+
+All of the 3 will yield the sare response:
+
+```json
+{
+  "givenName": "Bob",
+  "jobTitle": "Retail Manager",
+  "mail": "bob@contoso.com",
+  "mobilePhone": "+1 425 555 0109",
+  "officeLocation": "18/2111",
+  "preferredLanguage": "en-US",
+  "surname": "Vance",
+  "userPrincipalName": "bob@contoso.com",
+  "id": "1a89ade6-9f59-4fea-a139-23f84e3aef66"
+}
+```

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -2,10 +2,11 @@
 
 Microsoft Graph API Design Pattern
 
-*The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative attribute (called key) that is not its unique identifier*
+_The Alternate Key Pattern provides the ability to query for a single, specific resource identifiable through an alternative attribute (called key) that is not its unique identifier_
 
 ## Problem
---------
+
+---
 
 All entities in our system are identified by an [UUID (Universally Unique Identifier)](https://en.wikipedia.org/wiki/Universally_unique_identifier) - which guarantees uniqueness. Often though, that same resource can also be uniquely identified by an alternative, more convenient attribute that provides a better developer experience.
 
@@ -15,9 +16,9 @@ While it is still possible to use the oData filter, such as
 
 `https://graph.microsoft.com/v1.0/users?filter=mail eq 'bob@contoso.com'`, the returned result is wrapped in an array that needs to be unpacked.
 
-
 ## Solution
---------
+
+---
 
 oData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key attribute name to unambiguously determine the alternate key.
 
@@ -25,14 +26,16 @@ https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`
 
 ## When to Use this Pattern
-------------------------
+
+---
 
 This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client; while it does not work if the resultset has more than one element.
 
-In such case, we **strongly** advice to throw an exception and encourage the user to use `$filter` rather than returning the first result of the query 
+In such case, we **strongly** advice to throw an exception and encourage the user to use `$filter` rather than returning the first result of the query
 
 ## Example
--------
+
+---
 
 The same user identified via the alternate key SSN, the canonical (primary) key ID using the non-canonical long form with specified key attribute name, and the canonical short form without key attribute name
 
@@ -41,8 +44,3 @@ https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
 
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com')
-
-
-
-
-

--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -12,15 +12,15 @@ The resources exposed in Graph are identified through a Primary Key - which guar
 
 Take a look at the `user` resource: while the `id` remains a perfectly valid way to get the resource details, the `mail` address is also an unique property that could be used to identify it.
 
-While it is still possible to use the OData filter, such as
+While it is still possible to use the `$filter` query parameter, such as
 
-`https://graph.microsoft.com/v1.0/users?$filter=mail eq 'bob@contoso.com'`, the returned result is wrapped in an array that needs to be unpacked.
+`GET https://graph.microsoft.com/v1.0/users?$filter=mail eq 'bob@contoso.com'`, the returned result is wrapped in an array that needs to be unpacked.
 
 ## Solution
 
 ---
 
-OData offers resource addressing via an alternate key using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key. (Note: this is a hypothetical sample)
+Resource addressing via an alternative key can be achieved using the same parentheses-style convention as for the canonical key, with one difference: single-part alternate keys MUST specify the key property name to unambiguously determine the alternate key. (Note: this is a hypothetical sample)
 
 https://graph.microsoft.com/v1.0/users(0) - Retrieves the employee with ID = 0
 https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the employee with the email matching `bob@contoso.com`
@@ -29,7 +29,7 @@ https://graph.microsoft.com/v1.0/users(email='bob@contoso.com') Retrieves the em
 
 ---
 
-This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client; while it does not work if the resultset has more than one element. In such case, the workload SHOULD return `400`
+This pattern works and makes sense when the alternate key is good enough to identify a single resource and provides an useful alternative to the client.
 
 ## Example
 
@@ -40,7 +40,7 @@ The same user identified via the alternate key SSN, the canonical (primary) key 
 Declare `mail` and `ssn` as alternate keys on an entity:
 
 ```xml
-<EntityType Name="User">
+<EntityType Name="user">
    <Key>
      <PropertyRef Name="id" />
    </Key>
@@ -76,7 +76,7 @@ Declare `mail` and `ssn` as alternate keys on an entity:
 1. Get a specific resource through `$filter`:
 
 ```http
-GET https://graph.microsoft.com/v1.0/users/?$filter=(ssn eq '123-45-6789')
+GET https://graph.microsoft.com/v1.0/users/?$filter=ssn eq '123-45-6789'
 ```
 
 ```json
@@ -97,13 +97,15 @@ GET https://graph.microsoft.com/v1.0/users/?$filter=(ssn eq '123-45-6789')
 }
 ```
 
-2. Get a specific resource through its primary key, and then through the two alternate keys:
+2. Get a specific resource either through its primary key, or through the two alternate keys:
 
 ```http
 GET https://graph.microsoft.com/v1.0/users/1a89ade6-9f59-4fea-a139-23f84e3aef66
 GET https://graph.microsoft.com/v1.0/users(ssn='123-45-6789')
 GET https://graph.microsoft.com/v1.0/users(email='bob@contoso.com')
 ```
+
+**NOTE:** When requesting a resource through its primary key you might want to prefer to use key-as-segment (as shown above). Also, the key-as-segment does not work for alternate keys.
 
 All of the 3 will yield the sare response:
 


### PR DESCRIPTION
This PR adds a brief description of the Alternate Key Pattern discussed in the API Council.

It is not particularly long since the pattern per se is already extensively documented in the oData specification. This document could have just been "Use what we have in oData" :trollface: 
