### PR TITLE
Add note about URL-encoding for nextLink

### DIFF
--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -512,6 +512,8 @@ Note: To avoid potential collision of actions and resource ids, you should disal
 
 :white_check_mark: **DO** return a `nextLink` field with an absolute URL that the client can GET in order to retrieve the next page of the collection.
 
+Note: The service is responsible for performing any URL-encoding required on the `nextLink` URL.
+
 :white_check_mark: **DO** include any query parameters required by the service in `nextLink`, including `api-version`.
 
 :ballot_box_with_check: **YOU SHOULD** use `value` as the name of the top-level array field unless a more appropriate name is available.


### PR DESCRIPTION
This is a tiny PR to add a note saying that the service is responsible for any URL-encoding needed on the value of `nextLink`.