### PR TITLE
Clarify PATCH/PUT semantics and versioning behavior

### DIFF
--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -297,7 +297,7 @@ Because of this, required fields can only be introduced in the 1st version of a 
 
 When using this method | if this condition happens | use&nbsp;this&nbsp;response&nbsp;code
 ---------------------- | ------------------------- | ----------------------
-PATCH/PUT | Any JSON field name/value not known/valid | `400-Bad Request`
+PATCH/PUT | Any JSON field name/value not known/known to version/valid | `400-Bad Request`
 PATCH/PUT | Any Read field passed (client can't set Read fields) | `400-Bad Request`
 | **If&nbsp;the&nbsp;resource&nbsp;does&nbsp;not&nbsp;exist** |
 PATCH/PUT | Any mandatory Create/Update field missing | `400-Bad Request`

--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -297,7 +297,7 @@ Because of this, required fields can only be introduced in the 1st version of a 
 
 When using this method | if this condition happens | use&nbsp;this&nbsp;response&nbsp;code
 ---------------------- | ------------------------- | ----------------------
-PATCH/PUT | Any JSON field name/value not known/known to version/valid | `400-Bad Request`
+PATCH/PUT | Any JSON field name/value not known/valid to the api-version | `400-Bad Request`
 PATCH/PUT | Any Read field passed (client can't set Read fields) | `400-Bad Request`
 | **If&nbsp;the&nbsp;resource&nbsp;does&nbsp;not&nbsp;exist** |
 PATCH/PUT | Any mandatory Create/Update field missing | `400-Bad Request`


### PR DESCRIPTION
This PR contains two change requests:

1. The current guidelines say to use PATCH for create and update and to use PUT for wholesale create/update.  I personally find it challenging to parse the difference between these two things.  I was chatting with @tg-msft, and he said PATCH was recommended for update semantics and PUT was recommended for replace semantics, which I found easier to understand, and thought might be better to use to make the guidelines more self-explanatory.  If guidelines authors like this edit, you might consider going farther to clarify that the replace semantics are the equivalent of DELETE followed by PUT regardless of the version of the client.

2. While it says elsewhere in the guidelines to fail an operation if a value isn't fully understood by the version of the service, the text in the section on "Create / Update / Replace Processing Rules" does not call out failing on properties unknown to the version explicitly.  For clarity, it feels like it would be good to make this explicit in both places.