### PR TITLE
Guidelines.md - JSON properties names should be in lowerCamelCase.

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -493,7 +493,7 @@ For organizations to have a successful platform, they must serve data in formats
 
 Web-based communication, especially when a mobile or other low-bandwidth client is involved, has moved quickly in the direction of JSON for a variety of reasons, including its tendency to be lighter weight and its ease of consumption with JavaScript-based clients.
 
-JSON property names SHOULD be camelCased.
+JSON property names SHOULD be lowerCamelCased.
 
 Services SHOULD provide JSON as the default encoding.
 


### PR DESCRIPTION
Clarify that the JSON properties names should be in lowerCamelCase.

>17.2. Casing
>
>    Acronyms SHOULD follow the casing conventions as though they were regular words (e.g. Url).
>    All identifiers including namespaces, entityTypes, entitySets, properties, actions, functions and enumeration values SHOULD use **lowerCamelCase**.
>    HTTP headers are the exception and SHOULD use standard HTTP convention of Capitalized-Hyphenated-Terms.

https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#172-casing