### PR TITLE
Add a pattern description of a "draft" entity

### DIFF
--- a/graph/patterns/draft-entity.md
+++ b/graph/patterns/draft-entity.md
@@ -43,14 +43,16 @@ Doing this allows the storage of the partial data without compromising the integ
 
 ## When to use this pattern
 
-The "draft" entity pattern will be useful for workloads that are backing a UI and expose entities which the UI creates through the use of a multi-page process. 
+The "draft" entity pattern will be useful for workloads that back a UI and expose entities which the UI creates through the use of a multi-page process. 
 
 ## Issues and considerations
 
 This pattern should be avoided; instead, use some storage external to graph. TODO write down "why"
-This pattern *may* be used as a stop-gap if a workload does not yet have the infrastructure for external storage; these entities should be deprecated immediately since they are only a stop-gap.
+This pattern *may* be used as a stop-gap if a workload does not yet have the infrastructure for external storage; these entities must be deprecated immediately since they are only a stop-gap.
 
 ## Example
+
+### {1} Create a "real" instance with only partial data, getting an error
 
 ```HTTP
 POST /someRealEntities
@@ -67,6 +69,8 @@ POST /someRealEntities
 }
 ```
 
+### {2} Create a "draft" instance with only partial data
+
 ```HTTP
 POST /someRealEntityDrafts
 {
@@ -82,6 +86,8 @@ POST /someRealEntityDrafts
 }
 ```
 
+### {3} Try to realize the draft while it still only has partial data, getting an error
+
 ```HTTP
 POST /someRealEntityDrafts/{id}/realize
 
@@ -94,6 +100,8 @@ POST /someRealEntityDrafts/{id}/realize
 }
 ```
 
+### {4} Continue updating the draft with new data as the data becomes known
+
 ```HTTP
 PATCH /someRealEntityDrafts/{id}
 {
@@ -103,12 +111,16 @@ PATCH /someRealEntityDrafts/{id}
 204 No Content
 ```
 
+### {5} Realize the draft once all data has been provided
+
 ```HTTP
 POST /someRealEntityDrafts/{id}/realize
 
 204 No Content
 Location: /someRealEntities/{id2}
 ```
+
+### {6} Retrieve the realized instance
 
 ```HTTP
 GET /someRealEntities/{id2}

--- a/graph/patterns/draft-entity.md
+++ b/graph/patterns/draft-entity.md
@@ -47,7 +47,9 @@ The "draft" entity pattern will be useful for workloads that back a UI and expos
 
 ## Issues and considerations
 
-This pattern should be avoided; instead, use some storage external to graph. TODO write down "why"
+This pattern should be avoided; instead, use some storage external to graph. 
+Having entities that cannot be directly used by services because they are imcomplete and that have relaxed validation requirements effectively exposes an API that is equivalent to blob storage. 
+
 This pattern *may* be used as a stop-gap if a workload does not yet have the infrastructure for external storage; these entities must be deprecated immediately since they are only a stop-gap.
 
 ## Example

--- a/graph/patterns/draft-entity.md
+++ b/graph/patterns/draft-entity.md
@@ -1,0 +1,30 @@
+# "Draft" Entity
+
+Microsoft Graph API Design Pattern
+
+*A "draft" entity is one which can be used to temporarily store a subset of an entity that it is a draft of, avoiding validations that "real" instances of the entity would normally require.*
+
+
+## Problem
+
+*Describe the business context relevant for the pattern.*
+
+*Provide a short description of the problem.*
+
+## Solution
+
+*Describe how to implement the solution to solve the problem.*
+
+*Describe related patterns.*
+
+## When to use this pattern
+
+*Describe when and why the solution is applicable and when it might not be.*
+
+## Issues and considerations
+
+*Describe tradeoffs of the solution.*
+
+## Example
+
+*Provide a short example from real life.*

--- a/graph/patterns/draft-entity.md
+++ b/graph/patterns/draft-entity.md
@@ -4,26 +4,29 @@ Microsoft Graph API Design Pattern
 
 *A "draft" entity is one which can be used to temporarily store a subset of an entity that it is a draft of, avoiding validations that "real" instances of the entity would normally require.*
 
-
 ## Problem
 
-*Describe the business context relevant for the pattern.*
-
-*Provide a short description of the problem.*
+There are situations when a client only has a portion of the data required to create an entity at a given time. 
+In these situations, the client needs to store that partial data somewhere without requiring all of the data, and with allowing potentially invalid data to be present.
 
 ## Solution
 
-*Describe how to implement the solution to solve the problem.*
+The solution is to have a "draft" entity for the desired entity. 
+This "draft" can then be used to store the partial data until all of the data is available, at which time the "draft" can be used to create a "real" entity instance. 
+Doing this allows the storage of the partial data without compromising the integrity of the model for the "real" entity.
 
-*Describe related patterns.*
+```xml
+
+```
 
 ## When to use this pattern
 
-*Describe when and why the solution is applicable and when it might not be.*
+The "draft" entity pattern will be useful for workloads that are backing a UI and expose entities which the UI creates through the use of a multi-page process. 
 
 ## Issues and considerations
 
-*Describe tradeoffs of the solution.*
+This pattern should be avoided; instead, use some storage external to graph. 
+This pattern *may* be used as a stop-gap if a workload does not yet have the infrastructure for external storage; these entities should be deprecated immediately since they are only a stop-gap.
 
 ## Example
 

--- a/graph/patterns/draft-entity.md
+++ b/graph/patterns/draft-entity.md
@@ -44,6 +44,7 @@ Doing this allows the storage of the partial data without compromising the integ
 ## When to use this pattern
 
 The "draft" entity pattern will be useful for workloads that back a UI and expose entities which the UI creates through the use of a multi-page process. 
+It is also useful for any circumstances where the [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern) is effective, as this pattern is effectively a specialization of the builder pattern. 
 
 ## Issues and considerations
 


### PR DESCRIPTION
This pattern is really an anti-pattern which describes having a "draft" entity which has relaxed validation so that properties required to create the "real" entity can be added piecewise. In OOP, this is known as the "builder pattern".