### PR TITLE
Add guidance for the use of collections of entity types

### DIFF
--- a/graph/GuidelinesGraph.md
+++ b/graph/GuidelinesGraph.md
@@ -182,7 +182,9 @@ Another way to avoid this is to use JSON batch as described in the [Microsoft Gr
 
 You can model structured resources for your APIs by using the OData entity type or complex type. The main difference between these types is that an entity type declares a key property to uniquely identify its objects, and a complex type does not. In Microsoft Graph, this key property is called `id` for server-created key values. If there is a natural name for the key property, then the workload can use that.
 
-Because objects of complex types in Microsoft Graph don’t have unique identifiers, they are not directly addressable via URIs. Therefore, you must use entity types to model addressable resources such as individually addressable items within a collection. For more information, see the [Microsoft REST API Guidelines collection URL patterns](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#93-collection-url-patterns). Complex types are better suited to represent composite properties of API entities.
+Because objects of complex types in Microsoft Graph don’t have unique identifiers, they are not directly addressable via URIs. Therefore, you must use entity types to model addressable resources such as individually addressable items within a collection. For more information, see the [Microsoft REST API Guidelines collection URL patterns](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#93-collection-url-patterns).
+This is also why [collection properties](./collection-properties.md) should almost always be modeled using an entity type rather than a complex type. 
+Complex types are better suited to represent composite properties of API entities.
 
 ```xml
  <EntityType Name="author">

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -97,5 +97,19 @@ GET  /interestingData/bars
 
 ## Retrieving individual elements from a collection
 
-TODOD
-https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_RequestingIndividualEntities
+The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_RequestingIndividualEntities) also specifies that clients can retrieve individual elements of a collection of entity types:
+> To retrieve an individual entity, the client makes a GET request to a URL that identifies the entity, e.g. its read URL.
+
+However, there is no way to do this for complex types because there is not way to identity a particular instance of a complex type. 
+
+### Entity Type
+
+```HTTP
+GET  /interestingData/bars/firstBarId
+
+200 OK
+{
+  "id": "firstBarId",
+  "differentProperty": 42
+}
+```

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -1,0 +1,2 @@
+OData services treat collections of complex types differently than they treat collections of entity types. 
+This is due to the nature of entity types being "individually addressable" (they have some key which uniquely identifies them within the collection) while complex types are not individually addressable. 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -1,6 +1,6 @@
 OData services treat collections of complex types differently than they treat collections of entity types. 
 This is due to the nature of entity types being "individually addressable" (they have some key which uniquely identifies them within the collection) while complex types are not individually addressable. 
-The result of these differences is that it is almost always preferable to use entity types for collections rather than complex types; please see the exceptions [here](TODO).
+The result of these differences is that it is almost always preferable to use entity types for collections rather than complex types; please see the exceptions [here](#exceptions).
 Let's use the following CSDL as an example:
 
 ```xml

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -136,7 +136,7 @@ There is no way to do this for complex types because there is no way to identity
 ### Entity Type
 
 ```HTTP
-DELETE  /interestingData/bars/firstBarId
+DELETE  /interestingData/bars/thirdBarId
 
 204 No Content
 ```

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -1,6 +1,6 @@
 OData services treat collections of complex types differently than they treat collections of entity types. 
 This is due to the nature of entity types being "individually addressable" (they have some key which uniquely identifies them within the collection) while complex types are not individually addressable. 
-The result of this difference is that it is almost always preferable to use entity types for collections rather than complex types; please see the exceptions [here](#exceptions).
+As a result, it is almost always preferable to use entity types for collections rather than complex types. See [exceptions](#exceptions) for acceptable usage of complex types in collections.
 Let's use the following CSDL as an example:
 
 ```xml

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -1,4 +1,4 @@
-OData services treat collections of complex types differently than they treat collections of entity types. 
+Microsoft Graph treats collections of complex types differently than collections of entity types. 
 This is due to the nature of entity types being "individually addressable" (they have some key which uniquely identifies them within the collection) while complex types are not individually addressable. 
 As a result, it is almost always preferable to use entity types for collections rather than complex types. See [exceptions](#exceptions) for acceptable usage of complex types in collections.
 Let's use the following CSDL as an example:

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -336,7 +336,26 @@ GET /interestingData/bars
 
 #### Change the elements in a collection
 
-TODO
+```HTTP
+PATCH /interestingData/bars
+{
+  "@context": "#$delta",
+  "value": [
+    {
+      "id": "fifthBarId",
+      "differentProperty": 1024
+    },
+    {
+      "id": "sixthBarId",
+      "differentProperty": 9801
+    },
+    {
+      "id": "fourthBarId",
+      "@removed": {}
+    }
+  ]
+}
+```
 
 #### Check the new contents of the collection
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -1,2 +1,69 @@
 OData services treat collections of complex types differently than they treat collections of entity types. 
 This is due to the nature of entity types being "individually addressable" (they have some key which uniquely identifies them within the collection) while complex types are not individually addressable. 
+Let's use the following CSDL as an example:
+
+```xml
+<EntityType Name="interestingData">
+  <Property Name="foos" Type="Collection(self.foo)" Nullable="false" />
+  <NavitationProperty Name="bars" Type="Collection(self.bar)" Nullable="false" ContainsTarget="true" />
+</EntityType>
+
+<ComplexType Name="foo">
+  <Property Name="someProperty" Type="Edm.String" Nullable="false" />
+</ComplexType>
+
+<EntityType Name="bar">
+  <Key>
+    <PropertyRef Name="id" />
+  </Key>
+  <Property Name="id" Type="Edm.String" Nullable="false" />
+  <Property Name="differentProperty" Type="Edm.Int32" Nullable="false" />
+</EntityType>
+```
+
+## Adding elements to a collection
+
+For both `foos` and `bars`, the OData standard specifies that elements can be added to the collection using a `POST` request
+1. [Complex Types](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateaCollectionProperty):
+
+   > A successful POST request to the edit URL of a collection property adds an item to the collection.
+2. [Entity Types](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358976)
+
+   > To create an entity in a collection, the client sends a POST request to that collection's URL.
+
+### Complex Type
+
+```HTTP
+POST  /interestingData/foos
+{
+  "someProperty": "a value"
+}
+
+200 OK
+{
+  "value": [
+    {
+      "someProperty": "a value"
+    }
+  ]
+}
+```
+
+### Entity Type
+
+```HTTP
+POST  /interestingData/bars
+{
+  "differentProperty": 42
+}
+
+200 OK
+{
+  "value": [
+    {
+      "id": "firstBarId",
+      "differentProperty": 42
+    }
+  ]
+}
+```

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -23,39 +23,6 @@ Let's use the following CSDL as an example:
 </EntityType>
 ```
 
-## Adding individual elements to a collection
-
-For both `foos` and `bars`, the OData standard specifies that elements can be added to the collection using a `POST` request
-1. [Complex Types](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateaCollectionProperty):
-
-   > A successful POST request to the edit URL of a collection property adds an item to the collection.
-2. [Entity Types](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358976)
-
-   > To create an entity in a collection, the client sends a POST request to that collection's URL.
-
-### Complex Type
-
-```HTTP
-POST  /interestingData/foos
-{
-  "someProperty": "a value"
-}
-
-204 No Content
-```
-
-### Entity Type
-
-```HTTP
-POST  /interestingData/bars
-{
-  "differentProperty": 42
-}
-
-204 No Content
-Location: /interestingData/bars/thirdBarId
-```
-
 ## Retrieving the elements in a collection
 
 The [OData](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358935) [standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358947) specifies `foos` and `bars` both can be retrieved using a `GET` request:
@@ -75,9 +42,6 @@ GET  /interestingData/foos
   "value": [
     {
       "someProperty": "an original value"
-    },
-    {
-      "someProperty": "a value"
     }
   ]
 }
@@ -99,6 +63,81 @@ GET  /interestingData/bars
       "id": "secondBarId",
       "differentProperty": -6914
     }
+  ]
+}
+```
+
+## Adding individual elements to a collection
+
+For both `foos` and `bars`, the OData standard specifies that elements can be added to the collection using a `POST` request
+1. [Complex Types](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateaCollectionProperty):
+
+   > A successful POST request to the edit URL of a collection property adds an item to the collection.
+2. [Entity Types](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358976)
+
+   > To create an entity in a collection, the client sends a POST request to that collection's URL.
+
+### Complex Type
+
+#### Add an element to the collection
+
+```HTTP
+POST  /interestingData/foos
+{
+  "someProperty": "a value"
+}
+
+204 No Content
+```
+
+#### Check the new contents of the collection
+
+```HTTP
+GET  /interestingData/foos
+
+200 OK
+{
+  "value": [
+    {
+      "someProperty": "an original value"
+    },
+    {
+      "someProperty": "a value"
+    }
+  ]
+}
+```
+
+### Entity Type
+
+#### Add an element to the collection
+
+```HTTP
+POST  /interestingData/bars
+{
+  "differentProperty": 42
+}
+
+204 No Content
+Location: /interestingData/bars/thirdBarId
+```
+
+#### Check the new contents of the collection
+
+```HTTP
+GET  /interestingData/bars
+
+200 OK
+{
+  "value": [
+    {
+      "id": "firstBarId",
+      "differentProperty": 10
+    },
+    {
+      "id": "secondBarId",
+      "differentProperty": -6914
+    },
     {
       "id": "thirdBarId",
       "differentProperty": 42
@@ -135,10 +174,32 @@ There is no way to do this for complex types because there is no way to address 
 
 ### Entity Type
 
+#### Remove an element from the collection
+
 ```HTTP
 DELETE  /interestingData/bars/thirdBarId
 
 204 No Content
+```
+
+#### Check the new contents of the collection
+
+```HTTP
+GET  /interestingData/bars
+
+200 OK
+{
+  "value": [
+    {
+      "id": "firstBarId",
+      "differentProperty": 10
+    },
+    {
+      "id": "secondBarId",
+      "differentProperty": -6914
+    }
+  ]
+}
 ```
 
 ## Updating individual elements in a collection
@@ -150,6 +211,8 @@ There is no way to do this for complex types because there is no way to address 
 
 ### Entity Type
 
+#### Update an element in the collection
+
 ```HTTP
 PATCH  /interestingData/bars/firstBarId
 {
@@ -159,13 +222,110 @@ PATCH  /interestingData/bars/firstBarId
 204 No Content
 ```
 
-## Updating a collection
-/*
-https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateanEntity
-The semantics of PATCH, as defined in [RFC5789], is to merge the content in the request payload with the [entity’s] current state, applying the update only to those components specified in the request body. Collection properties and primitive properties provided in the payload corresponding to updatable properties MUST replace the value of the corresponding property in the entity or complex type. Missing properties of the containing entity or complex property, including dynamic properties, MUST NOT be directly altered unless as a side effect of changes resulting from the provided properties.
-*/
+#### Check the new contents of the collection
 
-TODO do PATCH for complex type and POST overwrite + delta PATCH for entity types
+```HTTP
+GET  /interestingData/bars
+
+200 OK
+{
+  "value": [
+    {
+      "id": "firstBarId",
+      "differentProperty": 15
+    },
+    {
+      "id": "secondBarId",
+      "differentProperty": -6914
+    }
+  ]
+}
+```
+
+## Updating a collection
+
+The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateanEntity) specifies that clients can replace all elements of a collection of complex types or all elements of a collection of entity types using a `PATCH` request:
+> Collection properties...provided in the payload corresponding to updatable properties MUST replace the value of the corresponding property in the entity or complex type.
+
+TODO the dstandard also blah blah delta path blah
+
+### Complex Type
+
+#### Replace the elements in a collection
+
+```HTTP
+PATCH /interestingData
+{
+  "foos": [
+    {
+      "someProperty": "a replacement value"
+    },
+    {
+      "someProperty": "more replacement value"
+    },
+    {
+      "someProperty": "a new value demonstrating that additional elements can be in the collection"
+    }
+  ]
+}
+
+204 No Content
+```
+
+#### Check the new contents of the collection
+
+```HTTP
+GET /interestingData/foos
+
+200 OK
+{
+  "value": [
+    {
+      "someProperty": "a replacement value"
+    },
+    {
+      "someProperty": "more replacement value"
+    },
+    {
+      "someProperty": "a new value demonstrating that additional elements can be in the collection"
+    }
+  ]
+}
+```
+
+### Entity Type
+
+#### Replace the elements in a collection
+
+```HTTP
+PATCH /interestingData
+{
+  "bars": [
+    {
+      "id": "fourthBarId",
+      "differentProperty": 20
+    }
+  ]
+}
+
+204 No Content
+```
+
+#### Check the new contents of the collection
+
+```HTTP
+GET /interestingData/bars
+
+200 OK
+{
+  "value": [
+    {
+      "id": "fourthBarId",
+      "differentProperty": 20
+    }
+  ]
+}
+```
 
 ## Exceptions
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -40,6 +40,35 @@ POST  /interestingData/foos
   "someProperty": "a value"
 }
 
+204 No Content
+```
+
+### Entity Type
+
+```HTTP
+POST  /interestingData/bars
+{
+  "differentProperty": 42
+}
+
+204 No Content
+Location: /interestingData/bars/firstBarId
+```
+
+## Retrieving the elements in a collection
+
+The [OData](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358935) [standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358947) also allows `foos` and `bars` both to be retrieved using a `GET` request:
+> OData services support requests for data via HTTP GET requests.
+> 
+> ...
+> 
+> OData services support querying collections of entities, complex type instances, and primitive values.
+
+### Complex Type
+
+```HTTP
+GET  /interestingData/foos
+
 200 OK
 {
   "value": [
@@ -53,10 +82,7 @@ POST  /interestingData/foos
 ### Entity Type
 
 ```HTTP
-POST  /interestingData/bars
-{
-  "differentProperty": 42
-}
+GET  /interestingData/bars
 
 200 OK
 {
@@ -69,4 +95,7 @@ POST  /interestingData/bars
 }
 ```
 
-## Retrieving elements from a collection
+## Retrieving individual elements from a collection
+
+TODOD
+https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_RequestingIndividualEntities

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -355,11 +355,29 @@ PATCH /interestingData/bars
     }
   ]
 }
+
+204 No Content
 ```
 
 #### Check the new contents of the collection
 
-TODO
+```HTTP
+GET /interestingData/bars
+
+200 OK
+{
+  "value": [
+    {
+      "id": "fifthBarId",
+      "differentProperty": 1024
+    },
+    {
+      "id": "sixthBarId",
+      "differentProperty": 9801
+    }
+  ]
+}
+```
 
 ## Exceptions
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -143,7 +143,21 @@ DELETE  /interestingData/bars/thirdBarId
 
 ## Updating individual elements in a collection
 
-TODO
+The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateanEntity) specifies that clients can update individual elements of a collection of entity types using a `PATCH` request:
+> To update an individual entity, the client makes a PATCH or PUT request to a URL that identifies the entity.
+
+There is no way to do this for complex types because there is no way to identity a particular instance of a complex type within a collection. 
+
+### Entity Type
+
+```HTTP
+PATCH  /interestingData/bars/firstBarId
+{
+  "differentProperty": "15"
+}
+
+204 No Content
+```
 
 ## Updating a collection
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -325,6 +325,10 @@ GET /interestingData/bars
     {
       "id": "fourthBarId",
       "differentProperty": 20
+    },
+    {
+      "id": "fifthBarId",
+      "differentProperty": -99999
     }
   ]
 }

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -22,7 +22,7 @@ Let's use the following CSDL as an example:
 </EntityType>
 ```
 
-## Adding elements to a collection
+## Adding individual elements to a collection
 
 For both `foos` and `bars`, the OData standard specifies that elements can be added to the collection using a `POST` request
 1. [Complex Types](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateaCollectionProperty):
@@ -113,3 +113,31 @@ GET  /interestingData/bars/firstBarId
   "differentProperty": 42
 }
 ```
+
+## Removing individual elements from a collection
+
+TODO
+
+## Updating individual elements in a collection
+
+TODO
+
+## Updating a collection
+
+TODO do PATCH for complex type and POST + PATCH for entity types
+
+## Exceptions
+
+TODO
+
+## Conclusion
+
+Collections of entity types have several behaviors that are not available for collections of complex types:
+1. Individual elements can be retrieved
+2. Individual elements can be removed
+3. Individual elements can be updated
+4. Several elements within the collection may be added, removed, or updated in a single request
+
+Further, to remove or update elements in a collection of complex types, the entire collection must be replace with a `PATCH` request. 
+This has the potential to result in data loss for clients who accidentally don't include all of the current elements of the collection, or encounter a race condition where two clients are attempting to `PATCH` the same collection.
+Due to the increased flexiblity of collections of entity types, and the data loss risks for collections of complex types, collections of entity types should be used. 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -1,5 +1,6 @@
 OData services treat collections of complex types differently than they treat collections of entity types. 
 This is due to the nature of entity types being "individually addressable" (they have some key which uniquely identifies them within the collection) while complex types are not individually addressable. 
+The result of these differences is that it is almost always preferable to use entity types for collections rather than complex types; please see the exceptions [here](TODO).
 Let's use the following CSDL as an example:
 
 ```xml
@@ -67,3 +68,5 @@ POST  /interestingData/bars
   ]
 }
 ```
+
+## Retrieving elements from a collection

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -250,8 +250,6 @@ The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-p
 The standard also specifies that collections of entities can be updated in a relative fashion using the [delta syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#_Toc38457777) in a `PATCH` request:
 > The body of a PATCH request to a URL identifying a collection of entities...MUST contain the context control information...and...MUST contain an array-valued property named value containing all added, changed, or deleted entities...
 
-TODO the dstandard also blah blah delta path blah
-
 ### Complex Type
 
 #### Replace the elements in a collection

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -247,6 +247,9 @@ GET  /interestingData/bars
 The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateanEntity) specifies that clients can replace all elements of a collection of complex types or all elements of a collection of entity types using a `PATCH` request:
 > Collection properties...provided in the payload corresponding to updatable properties MUST replace the value of the corresponding property in the entity or complex type.
 
+The standard also specifies that collections of entities can be updated in a relative fashion using the [delta syntax](https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#_Toc38457777) in a `PATCH` request:
+> The body of a PATCH request to a URL identifying a collection of entities...MUST contain the context control information...and...MUST contain an array-valued property named value containing all added, changed, or deleted entities...
+
 TODO the dstandard also blah blah delta path blah
 
 ### Complex Type
@@ -326,6 +329,14 @@ GET /interestingData/bars
   ]
 }
 ```
+
+#### Change the elements in a collection
+
+TODO
+
+#### Check the new contents of the collection
+
+TODO
 
 ## Exceptions
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -112,7 +112,7 @@ GET  /interestingData/bars
 The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_RequestingIndividualEntities) specifies that clients can retrieve individual elements of a collection of entity types using a `GET` request:
 > To retrieve an individual entity, the client makes a GET request to a URL that identifies the entity, e.g. its read URL.
 
-There is no way to do this for complex types because there is no way to identity a particular instance of a complex type within a collection. 
+There is no way to do this for complex types because there is no way to address a particular instance of a complex type within a collection. 
 
 ### Entity Type
 
@@ -131,7 +131,7 @@ GET  /interestingData/bars/firstBarId
 The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_DeleteanEntity) specifies that clients can remove individual elements of a collection of entity types using a `DELETE` request:
 > To delete an individual entity, the client makes a DELETE request to a URL that identifies the entity.
 
-There is no way to do this for complex types because there is no way to identity a particular instance of a complex type within a collection. 
+There is no way to do this for complex types because there is no way to address a particular instance of a complex type within a collection. 
 
 ### Entity Type
 
@@ -146,7 +146,7 @@ DELETE  /interestingData/bars/thirdBarId
 The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateanEntity) specifies that clients can update individual elements of a collection of entity types using a `PATCH` request:
 > To update an individual entity, the client makes a PATCH or PUT request to a URL that identifies the entity.
 
-There is no way to do this for complex types because there is no way to identity a particular instance of a complex type within a collection. 
+There is no way to do this for complex types because there is no way to address a particular instance of a complex type within a collection. 
 
 ### Entity Type
 
@@ -175,6 +175,6 @@ Collections of entity types have several behaviors that are not available for co
 3. Individual elements can be updated
 4. Several elements within the collection may be added, removed, or updated in a single request
 
-Further, to remove or update elements in a collection of complex types, the entire collection must be replace with a `PATCH` request. 
+Further, to remove or update elements in a collection of complex types, the entire collection must be replaced with a `PATCH` request. 
 This has the potential to result in data loss for clients who accidentally don't include all of the current elements of the collection, or encounter a race condition where two clients are attempting to `PATCH` the same collection.
 Due to the increased flexiblity of collections of entity types, and the data loss risks for collections of complex types, collections of entity types should be used. 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -7,7 +7,6 @@ Let's use the following CSDL as an example:
 <EntityType Name="interestingData">
   <Property Name="foos" Type="Collection(self.foo)" Nullable="false" />
   <NavitationProperty Name="bars" Type="Collection(self.bar)" Nullable="false" ContainsTarget="true" />
-  <!--TODO also add an example with primitives-->
 </EntityType>
 
 <ComplexType Name="foo">
@@ -379,7 +378,12 @@ GET /interestingData/bars
 
 ## Exceptions
 
-TODO
+It might not make sense for a collection property to be a collection of entities in cases where the collection must be viewed holistically; that is, cases where one element in the collection impacts or is coupled with another element in the collection. 
+The most common example of this would be a list of "tasks" that should be executed in order.
+Inserting a single task into a collection only makes sense because the client knows the preceeding and proceeding tasks.
+In cases like this, it might make sense for a collection to use a complex type instead of an entity type.
+However, even in this case, it might make sense to use a collection of entity types anyway so that clients can individually address the tasks in the list, having URLs to individual tasks that can be referred to. 
+In such a case, the delta `PATCH` request on this collection would simply be not supported. 
 
 ## Conclusion
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -160,8 +160,12 @@ PATCH  /interestingData/bars/firstBarId
 ```
 
 ## Updating a collection
+/*
+https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateanEntity
+The semantics of PATCH, as defined in [RFC5789], is to merge the content in the request payload with the [entity’s] current state, applying the update only to those components specified in the request body. Collection properties and primitive properties provided in the payload corresponding to updatable properties MUST replace the value of the corresponding property in the entity or complex type. Missing properties of the containing entity or complex property, including dynamic properties, MUST NOT be directly altered unless as a side effect of changes resulting from the provided properties.
+*/
 
-TODO do PATCH for complex type and POST + PATCH for entity types
+TODO do PATCH for complex type and POST overwrite + delta PATCH for entity types
 
 ## Exceptions
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -53,12 +53,12 @@ POST  /interestingData/bars
 }
 
 204 No Content
-Location: /interestingData/bars/firstBarId
+Location: /interestingData/bars/thirdBarId
 ```
 
 ## Retrieving the elements in a collection
 
-The [OData](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358935) [standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358947) also allows `foos` and `bars` both to be retrieved using a `GET` request:
+The [OData](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358935) [standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358947) specifies `foos` and `bars` both can be retrieved using a `GET` request:
 > OData services support requests for data via HTTP GET requests.
 > 
 > ...
@@ -73,6 +73,9 @@ GET  /interestingData/foos
 200 OK
 {
   "value": [
+    {
+      "someProperty": "an original value"
+    },
     {
       "someProperty": "a value"
     }
@@ -90,6 +93,14 @@ GET  /interestingData/bars
   "value": [
     {
       "id": "firstBarId",
+      "differentProperty": 10
+    },
+    {
+      "id": "secondBarId",
+      "differentProperty": -6914
+    }
+    {
+      "id": "thirdBarId",
       "differentProperty": 42
     }
   ]
@@ -98,10 +109,10 @@ GET  /interestingData/bars
 
 ## Retrieving individual elements from a collection
 
-The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_RequestingIndividualEntities) also specifies that clients can retrieve individual elements of a collection of entity types:
+The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_RequestingIndividualEntities) specifies that clients can retrieve individual elements of a collection of entity types using a `GET` request:
 > To retrieve an individual entity, the client makes a GET request to a URL that identifies the entity, e.g. its read URL.
 
-However, there is no way to do this for complex types because there is not way to identity a particular instance of a complex type. 
+There is no way to do this for complex types because there is no way to identity a particular instance of a complex type within a collection. 
 
 ### Entity Type
 
@@ -117,7 +128,18 @@ GET  /interestingData/bars/firstBarId
 
 ## Removing individual elements from a collection
 
-TODO
+The [OData standard](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_DeleteanEntity) specifies that clients can remove individual elements of a collection of entity types using a `DELETE` request:
+> To delete an individual entity, the client makes a DELETE request to a URL that identifies the entity.
+
+There is no way to do this for complex types because there is no way to identity a particular instance of a complex type within a collection. 
+
+### Entity Type
+
+```HTTP
+DELETE  /interestingData/bars/firstBarId
+
+204 No Content
+```
 
 ## Updating individual elements in a collection
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -1,6 +1,6 @@
 OData services treat collections of complex types differently than they treat collections of entity types. 
 This is due to the nature of entity types being "individually addressable" (they have some key which uniquely identifies them within the collection) while complex types are not individually addressable. 
-The result of these differences is that it is almost always preferable to use entity types for collections rather than complex types; please see the exceptions [here](#exceptions).
+The result of this difference is that it is almost always preferable to use entity types for collections rather than complex types; please see the exceptions [here](#exceptions).
 Let's use the following CSDL as an example:
 
 ```xml
@@ -160,7 +160,7 @@ GET  /interestingData/bars/firstBarId
 200 OK
 {
   "id": "firstBarId",
-  "differentProperty": 42
+  "differentProperty": 10
 }
 ```
 
@@ -304,6 +304,10 @@ PATCH /interestingData
     {
       "id": "fourthBarId",
       "differentProperty": 20
+    },
+    {
+      "id": "fifthBarId",
+      "differentProperty": -99999
     }
   ]
 }
@@ -383,7 +387,7 @@ The most common example of this would be a list of "tasks" that should be execut
 Inserting a single task into a collection only makes sense because the client knows the preceeding and proceeding tasks.
 In cases like this, it might make sense for a collection to use a complex type instead of an entity type.
 However, even in this case, it might make sense to use a collection of entity types anyway so that clients can individually address the tasks in the list, having URLs to individual tasks that can be referred to. 
-In such a case, the delta `PATCH` request on this collection would simply be not supported. 
+In such a case, the workload should simply not support a delta `PATCH` request on this collection.
 
 ## Conclusion
 

--- a/graph/collection-properties.md
+++ b/graph/collection-properties.md
@@ -7,6 +7,7 @@ Let's use the following CSDL as an example:
 <EntityType Name="interestingData">
   <Property Name="foos" Type="Collection(self.foo)" Nullable="false" />
   <NavitationProperty Name="bars" Type="Collection(self.bar)" Nullable="false" ContainsTarget="true" />
+  <!--TODO also add an example with primitives-->
 </EntityType>
 
 <ComplexType Name="foo">


### PR DESCRIPTION
I'm adding guidance to suggest that collections should be entity types instead of complex types because they can be modified piecewise, while collections of complex types must always be replaced, which can result in data loss and/or race conditions.

Please ignore the commit comments, I will perform a squash merge to complete the PR.