### PR TITLE
Remove the requirement for an enum property in the collection subsets pattern

### DIFF
--- a/graph/patterns/subsets.md
+++ b/graph/patterns/subsets.md
@@ -182,3 +182,36 @@ _Note: Unrelated properties on entities are omitted for easier readability._
     }
 }
 ```
+
+### Filter when base type has the "kind" enum property
+
+```HTTP
+GET .../memberships?$filter=membershipKind eq 'all'
+
+200 OK
+{
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.allMembership",
+      "membershipKind": "all"
+    },
+    ...
+  ]
+}
+```
+
+### Filter when base type lacks the "kind" enum property
+
+```HTTP
+GET .../memberships?$filter=isof(microsoft.graph.allMembership)
+
+200 OK
+{
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.allMembership",
+    },
+    ...
+  ]
+}
+```

--- a/graph/patterns/subsets.md
+++ b/graph/patterns/subsets.md
@@ -16,12 +16,18 @@ Existing patterns for this either have special-cased strings or have tightly cou
 
 Have an abstract base class where all variants of the subset are derived types from the base subset. For more information, see the [general subtyping guidance](./subtypes.md).
 
-The abstract base class should also hold an enum for all possible variants. The purpose of including this is to allow for easier ways to do query and filter operations on variants like `all` and `none` without relying on `isof` functions.
+The abstract base class may also optionally hold an `enum` for the different variants. If it does, the `enum` must have a member for all possible variants. The purpose of including this is to allow for easier ways to do query and filter operations on variants like `all` and `none` without relying on `isof` functions.
 
-**Base type**
+**Base type *without* an enum for the variants**
 
 ```xml
-    <ComplexType Name="membership" IsAbstract="true">
+    <ComplexType Name="membershipBase" IsAbstract="true" />
+```
+
+**Base type *with* an enum for the variants**
+
+```xml
+    <ComplexType Name="membershipBase" IsAbstract="true">
       <Property Name="membershipKind" Type="graph.membershipKind"/>
     </ComplexType>
 
@@ -36,15 +42,15 @@ The abstract base class should also hold an enum for all possible variants. The 
 **Derived types**
 
 ```xml
-    <ComplexType Name="noMembership" BaseType="graph.membership"/>
+    <ComplexType Name="noMembership" BaseType="graph.membershipBase"/>
 
-    <ComplexType Name="allMembership" BaseType="graph.membership"/>
+    <ComplexType Name="allMembership" BaseType="graph.membershipBase"/>
 
-    <ComplexType Name="enumeratedMembership" BaseType = "graph.membership">
+    <ComplexType Name="enumeratedMembership" BaseType = "graph.membershipBase">
       <Property Name="members" Type="Collection(Edm.String)"/>
     </ComplexType>
 
-    <ComplexType Name="excludedMembership" BaseType="graph.membership">
+    <ComplexType Name="excludedMembership" BaseType="graph.membershipBase">
       <Property Name="members" Type="Collection(Edm.String)"/>
     </ComplexType>
 ```
@@ -53,7 +59,7 @@ Be aware that the name values and types in the preceding examples are just examp
 
 These pattern type names should satisfy the following naming conventions:
 
-- The base type name should have the suffix `Base`, and the enumeration type name should have the suffix `Kind`.
+- The base type name should have the suffix `Base`, and the enumeration type name (if an `enum` is defined) should have the suffix `Kind`.
 - Derived child types should have names with enumeration values as the prefixes; for example, if the enumeration member value is `value1`, then the derived type name is `value1<type>`.
 
 ```xml

--- a/graph/patterns/subsets.md
+++ b/graph/patterns/subsets.md
@@ -185,33 +185,52 @@ _Note: Unrelated properties on entities are omitted for easier readability._
 
 ### Filter when base type has the "kind" enum property
 
-```HTTP
-GET .../memberships?$filter=membershipKind eq 'all'
+```http
+GET https://graph.microsoft.com/v1.0/identity/conditionalAccess/policies?$filter=conditions/users/includeGuestsOrExternalUsers/externalTenants/membershipKind eq 'all'
 
 200 OK
 {
-  "value": [
-    {
-      "@odata.type": "#microsoft.graph.allMembership",
-      "membershipKind": "all"
-    },
-    ...
-  ]
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#conditionalAccessPolicy",
+    "values": [
+        {
+            "id": "66d36273-fe4c-d478-dc22-e0179d856ce7",
+            "conditions": {
+                "users": {
+                    "includeGuestsOrExternalUsers": {
+                        "externalTenants": {
+                            "@odata.type":"microsoft.graph.conditionalAccessAllExternalTenants",
+                            "membershipKind": "all"
+                        }
+                    }
+                }
+            }
+        }
+    ]
 }
 ```
 
 ### Filter when base type lacks the "kind" enum property
 
 ```HTTP
-GET .../memberships?$filter=isof(microsoft.graph.allMembership)
+GET https://graph.microsoft.com/v1.0/identity/conditionalAccess/policies?$filter=isof(conditions/users/includeGuestsOrExternalUsers/externalTenants, microsoft.graph.conditionalAccessAllExternalTenants)
 
 200 OK
 {
-  "value": [
-    {
-      "@odata.type": "#microsoft.graph.allMembership",
-    },
-    ...
-  ]
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#conditionalAccessPolicy",
+    "values": [
+        {
+            "id": "66d36273-fe4c-d478-dc22-e0179d856ce7",
+            "conditions": {
+                "users": {
+                    "includeGuestsOrExternalUsers": {
+                        "externalTenants": {
+                            "@odata.type":"microsoft.graph.conditionalAccessAllExternalTenants",
+                            "membershipKind": "all"
+                        }
+                    }
+                }
+            }
+        }
+    ]
 }
 ```


### PR DESCRIPTION
The collection subsets pattern currently has a requirement that the base type should have an enum property which is parallel to and analogous with the dervied types. It was added to allow clients to more "easily" filter (they don't have to use `isof`). During reviews, we are often advising workload owners to *not* include the enum property, so this change removes it as a requirement, and explains that it is optional for cases where filtering using `isof` may be a concern. 