### PR TITLE
Update pagination guidance to clarify the difference between server-side and client-side paging

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -983,7 +983,7 @@ The `@nextLink` MAY be populated using either server-driven paging or client-dri
 #### 9.8.2. Server-driven paging
 
 The server MAY provide server-driven paging by populating the continuation token with a `$skiptoken` query parameter.
-The `$skiptoken` value is opague for clients and its structure should not be assumed.
+The `$skiptoken` value is opaque for clients and its structure should not be assumed.
 `$skiptoken` values SHOULD expire after some period of time decided by the server.
 
 Example:

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -982,7 +982,39 @@ The `@nextLink` MAY be populated using either server-driven paging or client-dri
 
 #### 9.8.2. Server-driven paging
 
-The server MAY provide
+The server MAY provide server-driven paging by populating the continuation token with a `$skiptoken` query parameter.
+The `$skiptoken` value is opague for clients and its structure should not be assumed.
+`$skiptoken` values SHOULD expire after some period of time.
+
+Example:
+
+```http
+GET http://api.contoso.com/v1.0/people HTTP/1.1
+Accept: application/json
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  ...,
+  "value": [...],
+  "@nextLink": "http://api.contoso.com/v1.0/people?$skiptoken={opaquetoken}"
+}
+```
+
+```http
+GET http://api.contoso.com/v1.0/people?$skiptoken={opaquetoken} HTTP/1.1
+Accept: application/json
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  ...,
+  "value": [...],
+  "@nextLink": "http://api.contoso.com/v1.0/people?$skiptoken={opaquetoken2}"
+}
+```
 
 #### 9.8.3. Client-driven paging
 Clients MAY use _$top_ and _$skip_ query parameters to specify a number of results to return and an offset into the collection.

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -984,7 +984,7 @@ The `@nextLink` MAY be populated using either server-driven paging or client-dri
 
 The server MAY provide server-driven paging by populating the continuation token with a `$skiptoken` query parameter.
 The `$skiptoken` value is opague for clients and its structure should not be assumed.
-`$skiptoken` values SHOULD expire after some period of time.
+`$skiptoken` values SHOULD expire after some period of time decided by the server.
 
 Example:
 

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -96,9 +96,10 @@ This document establishes the guidelines Microsoft REST APIs SHOULD follow so RE
       - [9.7.2. Operator examples](#972-operator-examples)
       - [9.7.3. Operator precedence](#973-operator-precedence)
     - [9.8. Pagination](#98-pagination)
-      - [9.8.1. Server-driven paging](#981-server-driven-paging)
-      - [9.8.2. Client-driven paging](#982-client-driven-paging)
-      - [9.8.3. Additional considerations](#983-additional-considerations)
+      - [9.8.1. Continuation tokens](#981-continuation-tokens)
+      - [9.8.2. Server-driven paging](#982-server-driven-paging)
+      - [9.8.3. Client-driven paging](#983-client-driven-paging)
+      - [9.8.4. Additional considerations](#984-additional-considerations)
     - [9.9. Compound collection operations](#99-compound-collection-operations)
     - [9.10. Empty Results](#910-empty-results)
   - [10. Delta queries](#10-delta-queries)
@@ -1008,7 +1009,7 @@ Content-Type: application/json
 }
 ```
 
-#### 9.8.3. Additional considerations
+#### 9.8.4. Additional considerations
 **Stable order prerequisite:** Both forms of paging depend on the collection of items having a stable order.
 The server MUST supplement any specified order criteria with additional sorts (typically by key) to ensure that items are always ordered consistently.
 

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -954,8 +954,9 @@ Client-driven paging enables clients to request only the number of resources tha
 
 Sorting and Filtering parameters MUST be consistent across pages, because both client- and server-side paging is fully compatible with both filtering and sorting.
 
-#### 9.8.1. Server-driven paging
-Paginated responses MUST indicate a partial result by including a continuation token in the response.
+#### 9.8.1. Continuation tokens
+
+Paginated responses MUST indicate a partial result by including a continuation token in the response using the OData control information `@nextLink`.
 The absence of a continuation token means that no additional pages are available.
 
 Clients MUST treat the continuation URL as opaque, which means that query options may not be changed while iterating over a set of partial results.
@@ -976,7 +977,13 @@ Content-Type: application/json
 }
 ```
 
-#### 9.8.2. Client-driven paging
+The `@nextLink` MAY be populated using either server-driven paging or client-driven paging (`@nextLink`s generated using client-driven paging should not include the `$top` query parameter).
+
+#### 9.8.2. Server-driven paging
+
+The server MAY provide
+
+#### 9.8.3. Client-driven paging
 Clients MAY use _$top_ and _$skip_ query parameters to specify a number of results to return and an offset into the collection.
 
 The server SHOULD honor the values specified by the client; however, clients MUST be prepared to handle responses that contain a different page size or contain a continuation token.

--- a/graph/GuidelinesGraph.md
+++ b/graph/GuidelinesGraph.md
@@ -168,7 +168,7 @@ Microsoft Graph APIs should support basic query options in conformance with ODat
 | :heavy_check_mark: **MUST** support `$select on resource` to enable properties projection. |
 | :ballot_box_with_check: **SHOULD** support `/entityTypeCollection/{id}?$expand=navProp1` option for navigation properties of entities. |
 | :ballot_box_with_check: **SHOULD** support `$filter` with `eq` and `ne` operations on properties of entity collections. |
-| :heavy_check_mark: **MUST** support pagination of collections ( of entity types or complex types) using a [nextLink](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationnextLinkodatanextL).  |
+| :heavy_check_mark: **MUST** support pagination of collections (of entity types or complex types) using a [nextLink](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationnextLinkodatanextL).  |
 | :ballot_box_with_check: **MAY** support [server-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#981-server-driven-paging) of collections using `$skiptoken`.  |
 | :ballot_box_with_check: **SHOULD** support [client-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#982-client-driven-paging) of collections using `$top` and `$skip`. |
 | :ballot_box_with_check: **SHOULD** support `$count` for collections. |

--- a/graph/GuidelinesGraph.md
+++ b/graph/GuidelinesGraph.md
@@ -168,8 +168,9 @@ Microsoft Graph APIs should support basic query options in conformance with ODat
 | :heavy_check_mark: **MUST** support `$select on resource` to enable properties projection. |
 | :ballot_box_with_check: **SHOULD** support `/entityTypeCollection/{id}?$expand=navProp1` option for navigation properties of entities. |
 | :ballot_box_with_check: **SHOULD** support `$filter` with `eq` and `ne` operations on properties of entity collections. |
-| :heavy_check_mark: **MUST** support [server-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#981-server-driven-paging) of collections using a [nextLink](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationnextLinkodatanextL).  |
-| :ballot_box_with_check: **SHOULD** support [client-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#982-client-driven-paging) of collections using `$top` and `$skip` (or `$skipToken`). |
+| :heavy_check_mark: **MUST** support pagination of collections ( of entity types or complex types) using a [nextLink](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationnextLinkodatanextL).  |
+| :ballot_box_with_check: **MAY** support [server-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#981-server-driven-paging) of collections using `$skiptoken`.  |
+| :ballot_box_with_check: **SHOULD** support [client-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#982-client-driven-paging) of collections using `$top` and `$skip`. |
 | :ballot_box_with_check: **SHOULD** support `$count` for collections. |
 | :ballot_box_with_check: **SHOULD** support sorting with `$orderby` both ascending and descending on properties of the entities. |
 

--- a/graph/GuidelinesGraph.md
+++ b/graph/GuidelinesGraph.md
@@ -150,26 +150,6 @@ In Microsoft Graph, a top-level API category might represent one of the followin
 
 Effectively, top-level categories define a perimeter for the API surface; thus, a new category creation requires additional rigor and governance approval.
 
-### Query support
-
-Microsoft Graph APIs should support basic query options in conformance with OData specifications and [Microsoft REST API Guidelines for error condition responses](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses).
-
-|Requirements                                                                                        |
-|----------------------------------------------------------------------------------------------------|
-| :heavy_check_mark: **MUST** support `$select on resource` to enable properties projection. |
-| :ballot_box_with_check: **SHOULD** support `/entityTypeCollection/{id}?$expand=navProp1` option for navigation properties of entities. |
-| :ballot_box_with_check: **SHOULD** support `$filter` with `eq` and `ne` operations on properties of entity collections. |
-| :heavy_check_mark: **MUST** support pagination of collections (of entity types or complex types) using a [nextLink](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationnextLinkodatanextL).  |
-| :ballot_box_with_check: **MAY** support [server-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#981-server-driven-paging) of collections using `$skiptoken`.  |
-| :ballot_box_with_check: **SHOULD** support [client-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#982-client-driven-paging) of collections using `$top` and `$skip`. |
-| :ballot_box_with_check: **SHOULD** support `$count` for collections. |
-| :ballot_box_with_check: **SHOULD** support sorting with `$orderby` both ascending and descending on properties of the entities. |
-
-The query options part of an OData URL can be quite long, potentially exceeding the maximum length of URLs supported by components involved in transmitting or processing the request. One way to avoid this is to use the POST verb instead of GET with the `$query` segment, and pass the query options part of the URL in the request body as described in the chapter
-[OData Query Options](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_PassingQueryOptionsintheRequestBody).
-
-Another way to avoid this is to use JSON batch as described in the [Microsoft Graph batching documentation](https://docs.microsoft.com/graph/json-batching#bypassing-url-length-limitations-with-batching).
-
 ### Resource modeling patterns
 
 You can model structured resources for your APIs by using the OData entity type or complex type. The main difference between these types is that an entity type declares a key property to uniquely identify its objects, and a complex type does not. In Microsoft Graph, this key property is called `id` for server-created key values. If there is a natural name for the key property, then the workload can use that.
@@ -257,8 +237,9 @@ Microsoft Graph APIs should support basic query options in conformance with ODat
 | :heavy_check_mark: **MUST** support `$select on resource` to enable properties projection. |
 | :ballot_box_with_check: **SHOULD** support `/entityTypeCollection/{id}?$expand=navProp1` option for navigation properties of entities. |
 | :ballot_box_with_check: **SHOULD** support `$filter` with `eq` and `ne` operations on properties of entity collections. |
-| :heavy_check_mark: **MUST** support [server-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#981-server-driven-paging) of collections using a [nextLink](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationnextLinkodatanextL).  |
-| :ballot_box_with_check: **SHOULD** support [client-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#982-client-driven-paging) of collections using `$top` and `$skip` (or `$skipToken`). |
+| :heavy_check_mark: **MUST** support pagination of collections (of entity types or complex types) using a [nextLink](http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationnextLinkodatanextL).  |
+| :ballot_box_with_check: **MAY** support [server-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#981-server-driven-paging) of collections using `$skiptoken`.  |
+| :ballot_box_with_check: **SHOULD** support [client-driven pagination](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#982-client-driven-paging) of collections using `$top` and `$skip`. |
 | :ballot_box_with_check: **SHOULD** support `$count` for collections. |
 | :ballot_box_with_check: **SHOULD** support sorting with `$orderby` both ascending and descending on properties of the entities. |
 


### PR DESCRIPTION
I noticed that we have been considering the use of `@nextLink` to be synonymous with server-driven paging. There are some workloads that provide a `@nextLink` using the `$skip` and `$top` query parameters. These workloads are "really" using client-driven paging since they make no guarantee that elements aren't missing or duplicated. I added a section to call out that services must use *some* form of pagination, and that they can use either server-driven, client-driven, or both. I also note that server-driven paging leverages the `$skiptoken` query paramter. 