### PR TITLE
Add guidance for crafting LRO permissions

### DIFF
--- a/graph/patterns/long-running-operations.md
+++ b/graph/patterns/long-running-operations.md
@@ -108,7 +108,7 @@ A client wants to provision a new database:
 POST https://graph.microsoft.com/v1.0/storage/databases/
 
 {
-"displayName": "Retail DB",
+  "displayName": "Retail DB",
 }
 ```
 
@@ -121,10 +121,10 @@ HTTP/1.1 201 Created
 Location: https://graph.microsoft.com/v1.0/storage/databases/db1
 
 {
-"id": "db1",
-"displayName": "Retail DB",
-"status": "provisioning",
-[ … other fields for "database" …]
+  "id": "db1",
+  "displayName": "Retail DB",
+  "status": "provisioning",
+  [ … other fields for "database" …]
 }
 ```
 
@@ -135,10 +135,10 @@ GET https://graph.microsoft.com/v1.0/storage/databases/db1
 
 HTTP/1.1 200 Ok
 {
-"id": "db1",
-"displayName": "Retail DB",
-"status": "succeeded",
-[ … other fields for "database" …]
+  "id": "db1",
+  "displayName": "Retail DB",
+  "status": "succeeded",
+  [ … other fields for "database" …]
 }
 ```
 
@@ -161,10 +161,10 @@ HTTP/1.1 202 Accepted
 Retry-After: 30
 
 {
-"id": "db1",
-"displayName": "Retail DB",
-"status": "deleting",
-[ … other fields for "database" …]
+  "id": "db1",
+  "displayName": "Retail DB",
+  "status": "deleting",
+  [ … other fields for "database" …]
 }
 ```
 
@@ -181,8 +181,8 @@ HTTP/1.1 404 Not Found
 POST https://graph.microsoft.com/v1.0/storage/archives/
 
 {
-"displayName": "Image Archive",
-...
+  "displayName": "Image Archive",
+  ...
 }
 ```
 
@@ -211,9 +211,9 @@ HTTP/1.1 200 OK
 Retry-After: 30
 
 {
-"createdDateTime": "2015-06-19T12-01-03.4Z",
-"lastActionDateTime": "2015-06-19T12-01-03.45Z",
-"status": "running"
+  "createdDateTime": "2015-06-19T12-01-03.4Z",
+  "lastActionDateTime": "2015-06-19T12-01-03.45Z",
+  "status": "running"
 }
 ```
 
@@ -232,10 +232,10 @@ location:
 HTTP/1.1 200 OK
 
 {
-"createdDateTime": "2015-06-19T12-01-03.45Z",
-"lastActionDateTime": "2015-06-19T12-06-03.0024Z",
-"status": "succeeded",
-"resourceLocation": "https://graph.microsoft.com/v1.0/storage/archives/987"
+  "createdDateTime": "2015-06-19T12-01-03.45Z",
+  "lastActionDateTime": "2015-06-19T12-06-03.0024Z",
+  "status": "succeeded",
+  "resourceLocation": "https://graph.microsoft.com/v1.0/storage/archives/987"
 }
 ```
 
@@ -245,8 +245,8 @@ HTTP/1.1 200 OK
 POST https://graph.microsoft.com/v1.0/storage/copyArchive
 
 {
-"displayName": "Image Archive",
-"destination": "Second-tier storage"
+  "displayName": "Image Archive",
+  "destination": "Second-tier storage"
 ...
 }
 ```

--- a/graph/patterns/long-running-operations.md
+++ b/graph/patterns/long-running-operations.md
@@ -57,10 +57,10 @@ There are some deviations from the base guidelines where Microsoft Graph API sta
   - The API response says the operation resource is being created at the URL provided in the Location header and indicates that the request is not completed by including a 202 status code.
   - Microsoft Graph doesn’t allow tenant-wide operation resources; therefore, stepwise operations are often modeled as a navigation property on the target resource.
 
-- For most implementations of the LRO pattern (like the example above), there will be 3 permissions necessary to comply with the principle of least privilege: `ArchiveOperation.ReadWrite.All` to create the operation entity, `ArchiveOperation.Read.All` to track the operation entity to completion, and `Archives.Read.All` to retrieve the resource that was created as a result of the operation.
+- For most implementations of the LRO pattern (like the example above), there will be 3 permissions necessary to comply with the principle of least privilege: `ArchiveOperation.ReadWrite.All` to create the `archiveOperation` entity, `ArchiveOperation.Read.All` to track the `archiveOperation` entity to completion, and `Archives.Read.All` to retrieve the `archive` that was created as a result of the operation.
 For APIs that would have been modeled as a simple `GET` on the resource URL, but that are modeled as long-running operations due to MSGraph performance requirements, only the `Archive.Read.All` permission is necessary as long as creating the `archiveOperation` entity is "safe".
-Here, "safe" means that there are no side effects for creating the `archiveOperation` entity that would change the functionality of any entities outside of the `archive` being retrieved.
-This requirment does not require the API to be idempotent, but an idempotent API is suffucient to meet this requirement.
+Here, "safe" means that there are no side effects of creating the `archiveOperation` entity that would change the functionality of any entities outside of the `archive` being retrieved.
+This requirment does not mean that the API must be idempotent, but an idempotent API is suffucient to meet this requirement.
 
 ## When to use this pattern
 

--- a/graph/patterns/long-running-operations.md
+++ b/graph/patterns/long-running-operations.md
@@ -57,6 +57,11 @@ There are some deviations from the base guidelines where Microsoft Graph API sta
   - The API response says the operation resource is being created at the URL provided in the Location header and indicates that the request is not completed by including a 202 status code.
   - Microsoft Graph doesn’t allow tenant-wide operation resources; therefore, stepwise operations are often modeled as a navigation property on the target resource.
 
+- For most implementations of the LRO pattern, there will be 3 permissions necessary to comply with the principle of least privilege: `{operation}.ReadWrite.All` to create the operation entity, `{operation.Read.All}` to track the operation entity to completion, and `{resource}.Read.All` to retrieve the resource that was created as a result of the operation.
+For APIs that would have been modeled as a simple `GET` on the resource URL, but that are modeled as long-running operations due to MSGraph performance requirements, only the `{resource}.Read.All` permission is necessary as long as creating the operation entity is "safe".
+Here, "safe" means that there are no side effects for creating the operation entity that would change the functioning of any entities outside of the resource being retrieved.
+This requirment is less strict than idempotence, and an idempotent API is suffucient to meet this requirement.
+
 ## When to use this pattern
 
 Any API call that is expected to take longer than one second in the 99th percentile should use the long running operations pattern.

--- a/graph/patterns/long-running-operations.md
+++ b/graph/patterns/long-running-operations.md
@@ -57,10 +57,10 @@ There are some deviations from the base guidelines where Microsoft Graph API sta
   - The API response says the operation resource is being created at the URL provided in the Location header and indicates that the request is not completed by including a 202 status code.
   - Microsoft Graph doesn’t allow tenant-wide operation resources; therefore, stepwise operations are often modeled as a navigation property on the target resource.
 
-- For most implementations of the LRO pattern, there will be 3 permissions necessary to comply with the principle of least privilege: `{operation}.ReadWrite.All` to create the operation entity, `{operation.Read.All}` to track the operation entity to completion, and `{resource}.Read.All` to retrieve the resource that was created as a result of the operation.
-For APIs that would have been modeled as a simple `GET` on the resource URL, but that are modeled as long-running operations due to MSGraph performance requirements, only the `{resource}.Read.All` permission is necessary as long as creating the operation entity is "safe".
-Here, "safe" means that there are no side effects for creating the operation entity that would change the functioning of any entities outside of the resource being retrieved.
-This requirment is less strict than idempotence, and an idempotent API is suffucient to meet this requirement.
+- For most implementations of the LRO pattern (like the example above), there will be 3 permissions necessary to comply with the principle of least privilege: `ArchiveOperation.ReadWrite.All` to create the operation entity, `ArchiveOperation.Read.All` to track the operation entity to completion, and `Archives.Read.All` to retrieve the resource that was created as a result of the operation.
+For APIs that would have been modeled as a simple `GET` on the resource URL, but that are modeled as long-running operations due to MSGraph performance requirements, only the `Archive.Read.All` permission is necessary as long as creating the `archiveOperation` entity is "safe".
+Here, "safe" means that there are no side effects for creating the `archiveOperation` entity that would change the functionality of any entities outside of the `archive` being retrieved.
+This requirment does not require the API to be idempotent, but an idempotent API is suffucient to meet this requirement.
 
 ## When to use this pattern
 


### PR DESCRIPTION
I have update the LRO guidance to reflect [this](https://microsoft.sharepoint.com/teams/APICouncil/_layouts/15/Doc.aspx?sourcedoc={3569deb7-5543-404f-99b0-70554b7f8778}&action=edit&wd=target%28ADRs.one%7C0edc1435-5069-4f42-8318-bf31c71c4e37%2FADR-018%20Permissions%20for%20long-running%20operations%7C8b0e2d1b-898c-4fcd-9e79-fe1d1be11d1e%2F%29&wdorigin=703) ADR that the permissions should illustrate the semantics of the operation rather than the HTTP/OData syntax of the requests. 

I also updated some formatting in the samples. 