### PR TITLE
Add guidelines on returning string offsets & lengths

### DIFF
--- a/azure/ConsiderationsForServiceDesign.md
+++ b/azure/ConsiderationsForServiceDesign.md
@@ -6,8 +6,9 @@
 
 | Date        | Notes                                                          |
 | ----------- | -------------------------------------------------------------- |
+| 2024-Jan-17 | Added guidelines on returning string offsets & lengths         |
 | 2022-Jul-15 | Update guidance on long-running operations                     |
-| 2022-Feb-01 | Updated error guidance                                        |
+| 2022-Feb-01 | Updated error guidance                                         |
 | 2021-Sep-11 | Add long-running operations guidance                           |
 | 2021-Aug-06 | Updated Azure REST Guidelines per Azure API Stewardship Board. |
 
@@ -517,7 +518,7 @@ By computing and returning ETags for your resources, you enable clients to avoid
 
 ## Returning String Offsets & Lengths (Substrings)
 
-Some Azure services return substring offset & length values within a string. For example, the offset & length within a string to a name, email address, or phone #.
+Some Azure services return substring offset & length values within a string. For example, the offset & length within a string to a name, email address, or phone number.
 When a service response includes a string, the client's programming language deserializes that string into that language's internal string encoding. Below are the possible encodings and examples of languages that use each encoding:
 
 | Encoding    | Example languages |
@@ -526,11 +527,11 @@ When a service response includes a string, the client's programming language des
 | UTF-16 | JavaScript, Java, C# |
 | CodePoint (UTF-32) | Python |
 
-Because the service doesn't know what language a client is written in and what string encoding that language uses, the service can't return UTF-agnostic offset and length values that the client can use to index within the string. To address this, the service response must include offset & length values for all 3 possible encodings and then the client code must select the encoding it required by its language's internal string encoding.
+Because the service doesn't know in what language a client is written and what string encoding that language uses, the service can't return UTF-agnostic offset and length values that the client can use to index within the string. To address this, the service response must include offset & length values for all 3 possible encodings and then the client code must select the encoding required by its language's internal string encoding.
 
 For example, if a service response needed to identify offset & length values for "name" and "email" substrings, the JSON response would look like this:
 
-```
+```json
 {
   (... other properties not shown...)
   "fullString": "(...some string containing a name and an email address...)",
@@ -538,24 +539,24 @@ For example, if a service response needed to identify offset & length values for
     "offset": {
       "utf8": 12,
       "utf16": 10,
-      "codePoint":  4
+      "codePoint": 4
     },
     "length": {
       "uft8": 10,
       "utf16": 8,
-      "codePoint":  2
+      "codePoint": 2
     }
   },
   "email": {
     "offset": {
       "utf8": 12,
       "utf16": 10,
-      "codePoint":  4
+      "codePoint": 4
     },
     "length": {
       "uft8": 10,
       "utf16": 8,
-      "codePoint":  4
+      "codePoint": 4
     }
   }
 }
@@ -563,7 +564,7 @@ For example, if a service response needed to identify offset & length values for
 
 Then, the Go developer, for example, would get the substring containing the name using code like this:
 
-```
+```go
    var response := client.SomeMethodReturningJSONShownAbove(...)
    name := response.fullString[ response.name.offset.utf8 : response.name.offset.utf8 + response.name.length.utf8]
 ```

--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -1107,6 +1107,14 @@ When a service response includes a string offset or length value, it should spec
 
 <a href="#substrings-return-value-for-each-encoding" name="substrings-return-value-for-each-encoding">:white_check_mark:</a> **DO** include all 3 encodings (UTF-8, UTF-16, and CodePoint) for every string offset or length value in a service response.
 
+<a href="#substrings-return-value-structure" name="substrings-return-value-structure">:white_check_mark:</a> **DO** define every string offset or length value in a service response as an object with the following structure:
+
+| Property    | Type    | Required | Description |
+| ----------- | ------- | :------: | ----------- |
+| `utf8`      | integer | true     | The offset or length of the substring in UTF-8 encoding |
+| `utf16`     | integer | true     | The offset or length of the substring in UTF-16 encoding |
+| `codePoint` | integer | true     | The offset or length of the substring in CodePoint encoding |
+
 <a href="#telemetry" name="telemetry"></a>
 ### Distributed Tracing & Telemetry
 Azure SDK client guidelines specify that client libraries must send telemetry data through the `User-Agent` header, `X-MS-UserAgent` header, and Open Telemetry.

--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -16,6 +16,7 @@ Please ensure that you add an anchor tag to any new guidelines that you add and 
 
 | Date        | Notes                                                          |
 | ----------- | -------------------------------------------------------------- |
+| 2024-Jan-17 | Added guidelines on returning string offsets & lengths         |
 | 2023-May-12 | Explain service response for missing/unsupported `api-version` |
 | 2023-Apr-21 | Update/clarify guidelines on POST method repeatability         |
 | 2023-Apr-07 | Update/clarify guidelines on polymorphism                      |
@@ -438,7 +439,7 @@ This indicates to client libraries and customers that values of the enumeration 
 
 Polymorphism types in REST APIs refers to the possibility to use the same property of a request or response to have similar but different shapes. This is commonly expressed as a `oneOf` in JsonSchema or OpenAPI. In order to simplify how to determine which specific type a given request or response payload corresponds to, Azure requires the use of an explicit discriminator field.
 
-Note: Polymorphic types can make your service more difficult for nominally typed languages to consume. See the corresponding section in the [Considerations for service design](./ConsiderationsForServiceDesign.md#avoid-surprises) for more information. 
+Note: Polymorphic types can make your service more difficult for nominally typed languages to consume. See the corresponding section in the [Considerations for service design](./ConsiderationsForServiceDesign.md#avoid-surprises) for more information.
 
 <a href="#json-use-discriminator-for-polymorphism" name="json-use-discriminator-for-polymorphism">:white_check_mark:</a> **DO** define a discriminator field indicating the kind of the resource and include any kind-specific fields in the body.
 
@@ -838,7 +839,7 @@ For example:
 ### Repeatability of requests
 
 Fault tolerant applications require that clients retry requests for which they never got a response, and services must handle these retried requests idempotently. In Azure, all HTTP operations are naturally idempotent except for POST used to create a resource and [POST when used to invoke an action](
-https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#performing-an-action). 
+https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#performing-an-action).
 
 <a href="#repeatability-headers" name="repeatability-headers">:ballot_box_with_check:</a> **YOU SHOULD** support repeatable requests as defined in [OASIS Repeatable Requests Version 1.0](https://docs.oasis-open.org/odata/repeatable-requests/v1.0/repeatable-requests-v1.0.html) for POST operations to make them retriable.
 - The tracked time window (difference between the `Repeatability-First-Sent` value and the current time) **MUST** be at least 5 minutes.
@@ -1097,6 +1098,14 @@ While it may be tempting to use a revision/version number for the resource as th
 <a href="#condreq-weak-etags-allowed" name="condreq-weak-etags-allowed">:heavy_check_mark:</a> **YOU MAY** consider Weak ETags if you have a valid scenario for distinguishing between meaningful and cosmetic changes or if it is too expensive to compute a hash.
 
 <a href="#condreq-etag-depends-on-encoding" name="condreq-etag-depends-on-encoding">:white_check_mark:</a> **DO**, when supporting multiple representations (e.g. Content-Encodings) for the same resource, generate different ETag values for the different representations.
+
+<a href="#substrings" name="substrings"></a>
+### Returning String Offsets & Lengths (Substrings)
+
+All string values in JSON are inherently Unicode and UTF-8 encoded, but clients written in a high-level programming language must work with strings in that language's string encoding, which may be UTF-8, UTF-16, or CodePoints (UTF-32).
+When a service response includes a string offset or length value, it should specify these values in all 3 encodings to simplify client development and ensure customer success when isolating a substring.
+
+<a href="#substrings-return-value-for-each-encoding" name="substrings-return-value-for-each-encoding">:white_check_mark:</a> **DO** include all 3 encodings (UTF-8, UTF-16, and CodePoint) for every string offset or length value in a service response.
 
 <a href="#telemetry" name="telemetry"></a>
 ### Distributed Tracing & Telemetry


### PR DESCRIPTION
This PR splits out the update for string offset and length from #517. I also reworked things a bit by moving the explanatory content over to ConsiderationsForServiceDesign.

It looks like my editor also trimmed some trailing whitespace from otherwise unchanged lines.