### PR TITLE
Update dictionary guidance to have the correct workload CSDL to implement a dictionary type

### DIFF
--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -37,7 +37,9 @@ For more information, see the [OData reference](https://github.com/oasis-tcs/oda
 
 ## Examples
 
-### Declaring a string dictionary
+### String dictionary
+
+#### CSDL declaration
 The following example demonstrates defining a dictionary that can contain string values.
 
 ```xml
@@ -60,7 +62,7 @@ The following example demonstrates defining a dictionary that can contain string
 Please note that schema validation will fail due to the casing of `Dictionary`.
 This warning should be suppressed.
 
-### Defining a dictionary property
+#### Defining a dictionary property
 The following example shows defining a dictionary property, "userTags", on the item entity type.
 
 ```xml
@@ -70,7 +72,7 @@ The following example shows defining a dictionary property, "userTags", on the i
 </EntityType>
 ```
 
-### Reading a dictionary
+#### Reading a dictionary
 Dictionaries are represented in JSON payloads as a JSON object, where the property names are comprised of the keys and their values are the corresponding key values. 
 
 The following example shows reading an item with a dictionary property named "userTags":
@@ -90,7 +92,7 @@ Response:
 }
 ```
 
-### Setting a dictionary value
+#### Setting a dictionary value
 The following example shows setting a dictionary value.  If "hairColor" already exists, it is updated, otherwise it is added.
 
 ```http
@@ -102,7 +104,7 @@ PATCH /item/userTags
 }
 ```
 
-### Deleting a dictionary value
+#### Deleting a dictionary value
 A dictionary value can be removed by setting the value to null.
 ```http
 PATCH /item/userTags
@@ -113,7 +115,9 @@ PATCH /item/userTags
 }
 ```
 
-### Declaring a complex typed dictionary
+### Complex typed dictionary
+
+#### CSDL declaration
 Dictionaries can also contain complex types whose values may be constrained to a particular set of complex types.
 
 The following example defines a complex type **roleSettings**, an **assignedRoleGroupDictionary** that contains **roleSettings**, and an **assignedRoles** property that uses the dictionary..
@@ -147,7 +151,7 @@ The following example defines a complex type **roleSettings**, an **assignedRole
 </Schema>
 ```
 
-### Reading a entity with a complex-typed dictionary
+#### Reading a entity with a complex-typed dictionary
 
 The following example illustrates reading an entity containing the complex-typed dictionary "assignedRoles".
 
@@ -175,7 +179,7 @@ Response:
 }
 ```
 
-### Reading the dictionary property
+#### Reading the dictionary property
 The following example shows getting just the "assignedRoles" dictionary property.
 
 ```HTTP

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -41,11 +41,13 @@ For more information, see the [OData reference](https://github.com/oasis-tcs/oda
 The following example demonstrates defining a dictionary that can contain string values.
 
 ```xml
-<Schema Namespace="WorkloadNamespace">
+<Schema Namespace="microsoft.graph">
   <ComplexType Name="Dictionary" OpenType="true">
     <Annotation Term="Core.Description" String="A dictionary of name-value pairs. Names must be valid property names, values may be restricted to a list of types via an annotation with term `Validation.OpenPropertyTypeConstraint`." />
   </ComplexType>
-  <ComplexType Name="stringDictionary" OpenType="true" BaseType="WorkloadNamespace.Dictionary">
+</Schema>
+<Schema Namespace="WorkloadNamespace">
+  <ComplexType Name="stringDictionary" OpenType="true" BaseType="microsoft.graph.Dictionary">
     <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">
       <Collection>
         <String>Edm.String</String>
@@ -64,7 +66,7 @@ The following example shows defining a dictionary property, "userTags", on the i
 ```xml
 <EntityType Name="item">
   ...
-  <Property Name="userTags" Type="self.stringDictionary"/>
+  <Property Name="userTags" Type="WorkloadNamespace.stringDictionary"/>
 </EntityType>
 ```
 
@@ -117,25 +119,33 @@ Dictionaries can also contain complex types whose values may be constrained to a
 The following example defines a complex type **roleSettings**, an **assignedRoleGroupDictionary** that contains **roleSettings**, and an **assignedRoles** property that uses the dictionary..
 
 ```xml
-<EntityType Name="principal">
-  ...
-  <Property Name="assignedRoles" Type="self.assignedRoleGroupDictionary">
-</EntityType>
 
-<ComplexType Name="roleSettings">
-  <Property Name ="domain" Type="Edm.String" Nullable="false" />
-</ComplexType>
+<Schema Namespace="microsoft.graph">
+  <ComplexType Name="Dictionary" OpenType="true">
+    <Annotation Term="Core.Description" String="A dictionary of name-value pairs. Names must be valid property names, values may be restricted to a list of types via an annotation with term `Validation.OpenPropertyTypeConstraint`." />
+  </ComplexType>
+</Schema>
+<Schema Namespace="WorkloadNamespace">
+  <EntityType Name="principal">
+    ...
+    <Property Name="assignedRoles" Type="WorkloadNamespace.assignedRoleGroupDictionary">
+  </EntityType>
 
-<ComplexType Name="assignedRoleGroupDictionary" BaseType="graph.Dictionary">
-  <!-- Note: Strongly-typed dictionary
-  of roleSettings
-  keyed by name of roleGroup. -->
-  <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">
-    <Collection>
-      <String>microsoft.graph.roleSettings</String>
-    </Collection>
-  </Annotation>
-</ComplexType>
+  <ComplexType Name="roleSettings">
+    <Property Name ="domain" Type="Edm.String" Nullable="false" />
+  </ComplexType>
+
+  <ComplexType Name="assignedRoleGroupDictionary" BaseType="microsoft.graph.Dictionary">
+    <!-- Note: Strongly-typed dictionary
+    of roleSettings
+    keyed by name of roleGroup. -->
+    <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">
+      <Collection>
+        <String>microsoft.graph.roleSettings</String>
+      </Collection>
+    </Annotation>
+  </ComplexType>
+</Schema>
 ```
 
 ### Reading a entity with a complex-typed dictionary

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -139,7 +139,7 @@ The following example defines a complex type **roleSettings**, an **assignedRole
   </ComplexType>
 
   <ComplexType Name="assignedRoleGroupDictionary" BaseType="microsoft.graph.Dictionary">
-    <!-- Note: Strongly-typed dictionary
+    <!-- Note: Strongly-typed dictionary of roleSettings keyed by name of roleGroup. -->
     of roleSettings
     keyed by name of roleGroup. -->
     <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -45,7 +45,7 @@ The following example demonstrates defining a dictionary that can contain string
   <ComplexType Name="Dictionary" OpenType="true">
     <Annotation Term="Core.Description" String="A dictionary of name-value pairs. Names must be valid property names, values may be restricted to a list of types via an annotation with term `Validation.OpenPropertyTypeConstraint`." />
   </ComplexType>
-  <ComplexType Name="stringDictionary" BaseType="WorkloadNamespace.Dictionary">
+  <ComplexType Name="stringDictionary" BaseType="WorkloadNamespace.Dictionary"> //// TODO does this need to be marked as an open type?
     <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">
       <Collection>
         <String>Edm.String</String>
@@ -54,6 +54,9 @@ The following example demonstrates defining a dictionary that can contain string
   </ComplexType>
 </Schema>
 ```
+
+Please note that schema validation will fail due to the casing of `Dictionary`.
+This warning should be suppressed.
 
 ### Defining a dictionary property
 The following example shows defining a dictionary property, "userTags", on the item entity type.

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -56,7 +56,7 @@ The following example demonstrates defining a dictionary that can contain string
 ```
 
 Please note that schema validation will fail due to the casing of `Dictionary`.
-This warning should be suppressed. //// TODO file issue for this
+This warning should be suppressed.
 
 ### Defining a dictionary property
 The following example shows defining a dictionary property, "userTags", on the item entity type.

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -41,7 +41,7 @@ For more information, see the [OData reference](https://github.com/oasis-tcs/oda
 The following example demonstrates defining a dictionary that can contain string values.
 
 ```xml
-<Schema Namespace="microsoft.graph">
+<Schema Namespace="microsoft.graph"> <!--NOTE: the namespace that declares the Dictionary complex type *must* be microsoft.graph-->
   <ComplexType Name="Dictionary" OpenType="true">
     <Annotation Term="Core.Description" String="A dictionary of name-value pairs. Names must be valid property names, values may be restricted to a list of types via an annotation with term `Validation.OpenPropertyTypeConstraint`." />
   </ComplexType>
@@ -119,8 +119,7 @@ Dictionaries can also contain complex types whose values may be constrained to a
 The following example defines a complex type **roleSettings**, an **assignedRoleGroupDictionary** that contains **roleSettings**, and an **assignedRoles** property that uses the dictionary..
 
 ```xml
-
-<Schema Namespace="microsoft.graph">
+<Schema Namespace="microsoft.graph"> <!--NOTE: the namespace that declares the Dictionary complex type *must* be microsoft.graph-->
   <ComplexType Name="Dictionary" OpenType="true">
     <Annotation Term="Core.Description" String="A dictionary of name-value pairs. Names must be valid property names, values may be restricted to a list of types via an annotation with term `Validation.OpenPropertyTypeConstraint`." />
   </ComplexType>

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -45,7 +45,7 @@ The following example demonstrates defining a dictionary that can contain string
   <ComplexType Name="Dictionary" OpenType="true">
     <Annotation Term="Core.Description" String="A dictionary of name-value pairs. Names must be valid property names, values may be restricted to a list of types via an annotation with term `Validation.OpenPropertyTypeConstraint`." />
   </ComplexType>
-  <ComplexType Name="stringDictionary" BaseType="WorkloadNamespace.Dictionary"> //// TODO does this need to be marked as an open type?
+  <ComplexType Name="stringDictionary" OpenType="true" BaseType="WorkloadNamespace.Dictionary">
     <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">
       <Collection>
         <String>Edm.String</String>

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -56,7 +56,7 @@ The following example demonstrates defining a dictionary that can contain string
 ```
 
 Please note that schema validation will fail due to the casing of `Dictionary`.
-This warning should be suppressed.
+This warning should be suppressed. //// TODO file issue for this
 
 ### Defining a dictionary property
 The following example shows defining a dictionary property, "userTags", on the item entity type.

--- a/graph/patterns/dictionary.md
+++ b/graph/patterns/dictionary.md
@@ -41,13 +41,18 @@ For more information, see the [OData reference](https://github.com/oasis-tcs/oda
 The following example demonstrates defining a dictionary that can contain string values.
 
 ```xml
-<ComplexType Name="stringDictionary" BaseType="graph.Dictionary">
-  <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">
-    <Collection>
-      <String>Edm.String</String>
-    </Collection>
-  </Annotation>
-</ComplexType>
+<Schema Namespace="WorkloadNamespace">
+  <ComplexType Name="Dictionary" OpenType="true">
+    <Annotation Term="Core.Description" String="A dictionary of name-value pairs. Names must be valid property names, values may be restricted to a list of types via an annotation with term `Validation.OpenPropertyTypeConstraint`." />
+  </ComplexType>
+  <ComplexType Name="stringDictionary" BaseType="WorkloadNamespace.Dictionary">
+    <Annotation Term="Org.OData.Validation.V1.OpenPropertyTypeConstraint">
+      <Collection>
+        <String>Edm.String</String>
+      </Collection>
+    </Annotation>
+  </ComplexType>
+</Schema>
 ```
 
 ### Defining a dictionary property


### PR DESCRIPTION
The current guidance does not pass the schema validation. I have updated it to reflect what actually passes schema validation (except for a single suppression that is required). You can find a repro of this guidance [here](https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/9433485). 