### PR TITLE
Add reference to String Offsets & Lengths topic in Considerations

### DIFF
--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -1104,6 +1104,9 @@ While it may be tempting to use a revision/version number for the resource as th
 
 All string values in JSON are inherently Unicode and UTF-8 encoded, but clients written in a high-level programming language must work with strings in that language's string encoding, which may be UTF-8, UTF-16, or CodePoints (UTF-32).
 When a service response includes a string offset or length value, it should specify these values in all 3 encodings to simplify client development and ensure customer success when isolating a substring.
+See the [Returning String Offsets & Lengths] section in Considerations for Service Design for more detail, including an example JSON response containing string offset and length fields.
+
+[Returning String Offsets & Lengths]: https://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#returning-string-offsets--lengths-substrings
 
 <a href="#substrings-return-value-for-each-encoding" name="substrings-return-value-for-each-encoding">:white_check_mark:</a> **DO** include all 3 encodings (UTF-8, UTF-16, and CodePoint) for every string offset or length value in a service response.
 


### PR DESCRIPTION
This PR adds a reference in the guidelines for String Offsets & Lengths to the corresponding section in Considerations for Service Design, which has more details and an example JSON response value.