### PR TITLE
Add guidance for types which should not have new structural properties

### DIFF
--- a/graph/GuidelinesGraph.md
+++ b/graph/GuidelinesGraph.md
@@ -336,7 +336,7 @@ For a complete mapping of error codes to HTTP statuses, see
 ### Limitations on core types
 
 The types `user`, `group`, and `device` should not have any new structural property(s) added, without compelling justification.
-Instead, model the concept represented in those property(s) as a new entity, and do one of the following:
+Instead, model the concept represented in those property(s) as a new entity and do one of the following:
 1. Add navigation from `user`, `group`, or `device` to the new entity.
 2. Add a navigation from the new entity to `user`, `group` or `device`.
 

--- a/graph/GuidelinesGraph.md
+++ b/graph/GuidelinesGraph.md
@@ -337,8 +337,8 @@ For a complete mapping of error codes to HTTP statuses, see
 
 The types `user`, `group`, and `device` should not have any new structural property(s) added, without compelling justification.
 Instead, model the concept represented in those property(s) as a new entity, and do one of the following:
-1. Add navigation to the new entity from `user`, `group`, or `device`.
-2. Contain the new entity elsewhere, and add a navigation from the new entity to `user`, `group` or `device`.
+1. Add navigation from `user`, `group`, or `device` to the new entity.
+2. Add a navigation from the new entity to `user`, `group` or `device`.
 
 More details and examples are available in [Core types](./articles/coreTypes.md).
 

--- a/graph/GuidelinesGraph.md
+++ b/graph/GuidelinesGraph.md
@@ -14,6 +14,7 @@ Table of contents
     - [Query support](#query-support)
     - [Behavior modeling](#behavior-modeling)
     - [Error handling](#error-handling)
+    - [Limitations on core types](#limitations-on-core-types)
   - [External standards](#external-standards)
   - [API contract and nonbackward compatible changes](#api-contract-and-nonbackward-compatible-changes)
     - [Versioning and deprecation](#versioning-and-deprecation)
@@ -331,6 +332,15 @@ For a complete mapping of error codes to HTTP statuses, see
 [rfc7231 (ietf.org)](https://datatracker.ietf.org/doc/html/rfc7231#section-6).
 
 <a name="api-contract-and-non-backward-compatible-changes"></a>
+
+### Limitations on core types
+
+The types `user`, `group`, and `device` should not have any new structural property(s) added, without compelling justification.
+Instead, model the concept represented in those property(s) as a new entity, and do one of the following:
+1. Add navigation to the new entity from `user`, `group`, or `device`.
+2. Contain the new entity elsewhere, and add a navigation from the new entity to `user`, `group` or `device`.
+
+More details and examples are available in [Core types](./articles/coreTypes.md).
 
 ## External standards
 

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -16,7 +16,7 @@ The following types are identified as core types, and will require strong justif
 
 ## Alternatives to Adding Structural Properties
 
-Instead of adding a structural property to the existing type (`user`, `group` or `device`), create a new type that models the information captured in the proposed structural property(s).
+Instead of adding a structural property to the existing core type (`user`, `group` or `device`), create a new type that models the information captured in the proposed structural property(s).
 Then, model the relationship between the existing core type and the new type by adding a navigation property. For information on modeling with navigation properties, see [Navigation Property](../patterns/navigation-property.md).
 
 ## Example:
@@ -38,7 +38,7 @@ Don't add new properties to core types such as `user`.
 
 Model the information by creating a new type and model the relationship to the existing core type with a navigation property. To determine which option is most appropriate, see [Navigation Property](../patterns/navigation-property.md):
 
-#### Option 1: Add a navigation property on the existing type to the new type, containing the new type.
+#### Option 1: Add a navigation property on the existing core type to the new type, containing the new type.
 
 Define the new entity type:
 ```xml
@@ -55,7 +55,7 @@ Add a contained navigation from user to the new entity type:
 </EntityType>
 ```
 
-#### Option 2: Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
+#### Option 2: Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing core type.
 
 Define the new entity type:
 ```xml
@@ -77,7 +77,7 @@ Add a navigation from user to the new type:
 </EntityType>
 ```
 
-#### Option 3: Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
+#### Option 3: Contain the new type in an entity set elsewhere, and add a navigation property to the existing core type on the new type.
 
 Define the new entity type, with a navigation to the user:
 ```xml

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Types exist in Microsoft Graph which are highly-connected/central to the Microsoft Graph ecosystem. Often, these types are in the position of containing many structural properties relevant to other APIs, because they are connected to many entities in the Microsoft Graph.
+Types exist in Microsoft Graph which are highly-connected/central to the Microsoft Graph ecosystem. Often, these types are in the position of containing many structural properties relevant to other APIs, because they are connected to many entities in Microsoft Graph.
 
 Structural properties should be only added to these core types when they are properties of the entity itself and strictly not for the purpose of convenience due to the entity's position in Microsoft Graph.
 

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -58,7 +58,7 @@ Add a contained navigation from user to the new entity type:
 </EntityType>
 ```
 
-#### Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
+#### Option 2: Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
 
 Define the new entity type:
 ```xml

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Types exist in graph which are highly-connected/central to the graph ecosystem. Often, these types are in the position of containing many structural properties relevant to other APIs, because they are connected to many entities in the graph.
+Types exist in Microsoft Graph which are highly-connected/central to the Microsoft Graph ecosystem. Often, these types are in the position of containing many structural properties relevant to other APIs, because they are connected to many entities in the Microsoft Graph.
 
-Structural properties should be only added to these core types when they are properties of the entity itself and strictly not for the purpose of convenience due to the entity's position in the graph.
+Structural properties should be only added to these core types when they are properties of the entity itself and strictly not for the purpose of convenience due to the entity's position in Microsoft Graph.
 
-## Core Types in Graph
+## Core Types in Microsoft Graph
 
 The following types are identified as core types, and will require strong justification to allow new structural properties to be added in all cases.
 

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-Types exist in Microsoft Graph which are highly-connected/central to the Microsoft Graph ecosystem. Often, these types are in the position of containing many structural properties relevant to other APIs, because they are connected to many entities in Microsoft Graph.
+Types exist in Microsoft Graph which are highly-connected/central to the Microsoft Graph ecosystem. Often, these types are in the position of being able to contain structural properties relevant to other APIs, because they are connected to many entities in Microsoft Graph.
 
-Structural properties should be only added to these core types when they are properties of the entity itself and strictly not for the purpose of convenience due to the entity's position in Microsoft Graph.
+Structural properties should be only added to these core types when they are intrinsic to the entity itself, and strictly not for the purpose of convenience due to the entity's position in Microsoft Graph.
 
 ## Core Types in Microsoft Graph
 

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -41,7 +41,7 @@ Don't add new properties to core types such as `user`.
 
 Do one of the following:
 
-#### Add a navigation property on the existing type to the new type, containing the new type.
+#### Option 1: Add a navigation property on the existing type to the new type, containing the new type.
 
 Define the new entity type:
 ```xml

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -45,7 +45,7 @@ Do one of the following:
 
 Define the new entity type:
 ```xml
-<EntityType name="bankAccountInformation">
+<EntityType name="bankAccountDetail">
     <Property Name="accountNumber" Type="Edm.string"/>
     <Property Name="routingNumber" Type="Edm.string"/>
 </EntityType>
@@ -54,7 +54,7 @@ Define the new entity type:
 Add a contained navigation from user to the new entity type:
 ```xml
 <EntityType name="user">
-    <NavigationProperty Name="bankAccountInformation" Type="bankAccountInformation" ContainsTarget="true"/>
+    <NavigationProperty Name="bankAccountDetail" Type="bankAccountDetail" ContainsTarget="true"/>
 </EntityType>
 ```
 
@@ -62,7 +62,7 @@ Add a contained navigation from user to the new entity type:
 
 Define the new entity type:
 ```xml
-<EntityType name="bankAccountInformation">
+<EntityType name="bankAccountDetail">
     <Property Name="accountNumber" Type="Edm.string"/>
     <Property Name="routingNumber" Type="Edm.string"/>
 </EntityType>
@@ -70,13 +70,13 @@ Define the new entity type:
 
 Contain the new entity type in an entity set or singleton:
 ```xml
-<EntitySet Name="bankAccountInformations" EntityType="bankAccountInformation">
+<EntitySet Name="bankAccountDetails" EntityType="bankAccountDetail">
 ```
 
 Add a navigation from user to the new type:
 ```xml
 <EntityType name="user">
-    <NavigationProperty Name="bankAccountInformation" Type="bankAccountInformation" />
+    <NavigationProperty Name="bankAccountDetail" Type="bankAccountDetail" />
 </EntityType>
 ```
 
@@ -84,7 +84,7 @@ Add a navigation from user to the new type:
 
 Define the new entity type, with a navigation to the user:
 ```xml
-<EntityType name="bankAccountInformation">
+<EntityType name="bankAccountDetail">
     <Property Name="accountNumber" Type="Edm.string"/>
     <Property Name="routingNumber" Type="Edm.string"/>
     <NavigationProperty Name="user" Type="microsoft.graph.user" />

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Types exist in graph which are highly-connected/central to the graph ecosystem. Often, these types are the position of containing many structural properties relevant to other APIs, because they are connected to many entities in the graph.
+Types exist in graph which are highly-connected/central to the graph ecosystem. Often, these types are in the position of containing many structural properties relevant to other APIs, because they are connected to many entities in the graph.
 
 Structural properties should be only added to these core types when they are properties of the entity itself and strictly not for the purpose of convenience due to the entity's position in the graph.
 

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -80,7 +80,7 @@ Add a navigation from user to the new type:
 </EntityType>
 ```
 
-#### Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
+#### Option 3: Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
 
 Define the new entity type, with a navigation to the user:
 ```xml

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -17,10 +17,7 @@ The following types are identified as core types, and will require strong justif
 ## Alternatives to Adding Structural Properties
 
 Instead of adding a structural property to the existing type (`user`, `group` or `device`), create a new type that models the information captured in the proposed structural property(s).
-Then, do one of the following:
-- Add a navigation property on the existing type to the new type, containing the new type.
-- Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
-- Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
+Then, model the relationship between the existing core type and the new type by adding a navigation property. For information on modeling with navigation properties, see [Navigation Property](../patterns/navigation-property.md).
 
 ## Example:
 
@@ -39,7 +36,7 @@ Don't add new properties to core types such as `user`.
 
 ### Do:
 
-Do one of the following:
+Model the information by creating a new type and model the relationship to the existing core type with a navigation property. To determine which option is most appropriate, see [Navigation Property](../patterns/navigation-property.md):
 
 #### Option 1: Add a navigation property on the existing type to the new type, containing the new type.
 

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -19,8 +19,8 @@ The following types are identified as core types, and will require strong justif
 Instead of adding a structural property to the existing type (`user`, `group` or `device`), create a new type that models the information captured in the proposed structural property(s).
 Then, do one of the following:
 - Add a navigation property on the existing type to the new type, containing the new type.
-- Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
 - Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
+- Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
 
 ## Example:
 
@@ -39,8 +39,11 @@ Don't add new properties to core types such as `user`.
 
 ### Do:
 
-First, create a new type that models the information captured in the desired structural property(s).
+Do one of the following:
 
+#### Add a navigation property on the existing type to the new type, containing the new type.
+
+Define the new entity type:
 ```xml
 <EntityType name="bankAccountInformation">
     <Property Name="accountNumber" Type="Edm.string"/>
@@ -48,10 +51,47 @@ First, create a new type that models the information captured in the desired str
 </EntityType>
 ```
 
-Then, for example, add a navigation property on the existing type, containing the new type:
-
+Add a contained navigation from user to the new entity type:
 ```xml
 <EntityType name="user">
     <NavigationProperty Name="bankAccountInformation" Type="bankAccountInformation" ContainsTarget="true"/>
 </EntityType>
+```
+
+#### Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
+
+Define the new entity type:
+```xml
+<EntityType name="bankAccountInformation">
+    <Property Name="accountNumber" Type="Edm.string"/>
+    <Property Name="routingNumber" Type="Edm.string"/>
+</EntityType>
+```
+
+Contain the new entity type in an entity set or singleton:
+```xml
+<EntitySet Name="bankAccountInformations" EntityType="bankAccountInformation">
+```
+
+Add a navigation from user to the new type:
+```xml
+<EntityType name="user">
+    <NavigationProperty Name="bankAccountInformation" Type="bankAccountInformation" />
+</EntityType>
+```
+
+#### Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
+
+Define the new entity type, with a navigation to the user:
+```xml
+<EntityType name="bankAccountInformation">
+    <Property Name="accountNumber" Type="Edm.string"/>
+    <Property Name="routingNumber" Type="Edm.string"/>
+    <NavigationProperty Name="user" Type="microsoft.graph.user" />
+</EntityType>
+```
+
+Contain the new entity type in an entity set or singleton:
+```xml
+<EntitySet Name="bankAccountInformations" EntityType="bankAccountInformation">
 ```

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -16,12 +16,11 @@ The following types are identified as core types, and will require strong justif
 
 ## Alternatives to Adding Structural Properties
 
-Instead of adding a structural property to an existing type, do the following:
-1. Create a new type that models the information captured in the proposed structural property.
-2. Create a navigation property linking the new type to the existing type, doing one of the following:
-   - Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
-   - Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
-   - Add a navigation property to the new type on the existing type, containing the new type.
+Instead of adding a structural property to the existing type (`user`, `group` or `device`), create a new type that models the information captured in the proposed structural property(s).
+Then, do one of the following:
+- Add a navigation property on the existing type to the new type, containing the new type.
+- Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
+- Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
 
 ## Example:
 
@@ -40,16 +39,18 @@ Don't add new properties to core types such as `user`.
 
 ### Do:
 
-Instead, create a new entity modeling the concept that you wish to introduce, and create a navigation property connecting that entity to the desired type.
+First, create a new type that models the information captured in the desired structural property(s).
 
 ```xml
 <EntityType name="bankAccountInformation">
     <Property Name="accountNumber" Type="Edm.string"/>
     <Property Name="routingNumber" Type="Edm.string"/>
 </EntityType>
+```
 
-...
+Then, for example, add a navigation property on the existing type, containing the new type:
 
+```xml
 <EntityType name="user">
     <NavigationProperty Name="bankAccountInformation" Type="bankAccountInformation" ContainsTarget="true"/>
 </EntityType>

--- a/graph/articles/coreTypes.md
+++ b/graph/articles/coreTypes.md
@@ -1,0 +1,56 @@
+# Core Types
+
+## Overview
+
+Types exist in graph which are highly-connected/central to the graph ecosystem. Often, these types are the position of containing many structural properties relevant to other APIs, because they are connected to many entities in the graph.
+
+Structural properties should be only added to these core types when they are properties of the entity itself and strictly not for the purpose of convenience due to the entity's position in the graph.
+
+## Core Types in Graph
+
+The following types are identified as core types, and will require strong justification to allow new structural properties to be added in all cases.
+
+- ```user```
+- ```group```
+- ```device```
+
+## Alternatives to Adding Structural Properties
+
+Instead of adding a structural property to an existing type, do the following:
+1. Create a new type that models the information captured in the proposed structural property.
+2. Create a navigation property linking the new type to the existing type, doing one of the following:
+   - Contain the new type in an entity set elsewhere, and add a navigation property to the existing type on the new type.
+   - Contain the new type in an entity set elsewhere, and add a navigation property to the new type on the existing type.
+   - Add a navigation property to the new type on the existing type, containing the new type.
+
+## Example:
+
+Modeling adding "bank account information", which includes two properties `accountNumber` and `routingNumber`, to entity type ```user```.
+
+### Don't:
+
+Don't add new properties to core types such as `user`.
+
+```xml
+<EntityType name="user">
+    <Property Name="accountNumber" Type="Edm.string"/>
+    <Property Name="routingNumber" Type="Edm.string"/>
+</EntityType>
+```
+
+### Do:
+
+Instead, create a new entity modeling the concept that you wish to introduce, and create a navigation property connecting that entity to the desired type.
+
+```xml
+<EntityType name="bankAccountInformation">
+    <Property Name="accountNumber" Type="Edm.string"/>
+    <Property Name="routingNumber" Type="Edm.string"/>
+</EntityType>
+
+...
+
+<EntityType name="user">
+    <NavigationProperty Name="bankAccountInformation" Type="bankAccountInformation" ContainsTarget="true"/>
+</EntityType>
+```


### PR DESCRIPTION
Adding guidance that there should not be new structural properties added to `user`, `group`, `device`.