### PR TITLE
Include nextLink in header

### DIFF
--- a/azure/Guidelines.md
+++ b/azure/Guidelines.md
@@ -566,6 +566,14 @@ Note: The service is responsible for performing any URL-encoding required on the
 
 <a href="#collections-nextlink-includes-all-query-params" name="collections-nextlink-includes-all-query-params">:white_check_mark:</a> **DO** include any query parameters required by the service in `nextLink`, including `api-version`.
 
+<a href="#collections-include-nextlink-header-for-more-results" name="collections-include-nextlink-header-for-more-results">:white_check_mark:</a> **DO** also include the same `nextLink` URL and query parameters in the [`Link` header](https://httpwg.org/specs/rfc8288.html#link-target) with `rel="next"`:
+
+```
+Link: <{opaqueUrl}>; rel="next"
+```
+
+This allows client libraries to provide abstractions to loop through results without having to spend computational resources to deserialize the response body just to get the `nextLink`.
+
 <a href="#collections-response-array-name" name="collections-response-array-name">:ballot_box_with_check:</a> **YOU SHOULD** use `value` as the name of the top-level array field unless a more appropriate name is available.
 
 <a href="#collections-no-nextlink-on-last-page" name="collections-no-nextlink-on-last-page">:no_entry:</a> **DO NOT** return the `nextLink` field at all when returning the last page of the collection.


### PR DESCRIPTION
Allows client libraries that would otherwise deserialize lazily to return an abstraction that returns the page of results without having to deserialize the body.

Azure SDKs that will (or may) benefit from this include:

* Rust
* Java
* (Possibly) .NET
* (Possibly) C++

For Rust, we provide a `Stream` implementation where the customer deserializing our models or theirs is actually polling the future (backing Rust's async). We are not in the stack so we can't get the `nextLink` unless we first deserialize the response body, which also means that we are having to poll the future to completion instead of the customer during deserialization. This is a waste of time and resources: if we were to reuse the same models we might otherwise give them in the golden path (simple method call to deserialize into our "suggested" model), much time is spent allocating strings on the heap, for example. Even if we create private models just to deserialize the `nextLink`, we're still polling the future to completion and parsing through all the bytes just to get a `String` for the `nextLink` out of it. We then do a shallow copy of that buffer and pass it back to the client so they can deserialize our models or theirs. Java, I'm told, works similarly and .NET is considering similar designs.