### PR TITLE
docs: remove duplicate word in alternate key example

### DIFF
--- a/graph/patterns/alternate-key.md
+++ b/graph/patterns/alternate-key.md
@@ -162,7 +162,7 @@ Declare `mail` and `ssn` as alternate keys on an entity:
     {
         "error" : {
             "code" : "404",
-            "message": "No user with the the specified 'email' could be found."
+            "message": "No user with the specified 'email' could be found."
         }
     }
     ```


### PR DESCRIPTION
## Summary\n- remove a duplicate word in the alternate key error message example\n\n## Related issue\n- N/A\n\n## Guideline alignment\n- https://github.com/microsoft/api-guidelines/blob/vNext/CONTRIBUTING.md\n\n## Validation\n- Not run (doc-only change)