### PR TITLE
docs: fix hero scenarios typo

### DIFF
--- a/azure/ConsiderationsForServiceDesign.md
+++ b/azure/ConsiderationsForServiceDesign.md
@@ -58,7 +58,7 @@ It is extremely difficult to create an elegant API that works well on top of a p
 The whole purpose of a preview to address feedback by improving abstractions, naming, relationships, API operations, and so on. It is OK to make breaking changes during a preview to improve the experience now so that it is sustainable long term.
 
 ## Focus on Hero Scenarios
-It is important to realize that writing an API is, in many cases, the easiest part of providing a delightful developer experience. There are a large number of downstream activities for each API, e.g. testing, documentation, client libraries, examples, blog posts, videos, and supporting customers in perpetuity. In fact, implementing an API is of miniscule cost compared to all the other downstream activities.
+It is important to realize that writing an API is, in many cases, the easiest part of providing a delightful developer experience. There are a large number of downstream activities for each API, e.g. testing, documentation, client libraries, examples, blog posts, videos, and supporting customers in perpetuity. In fact, implementing an API is of minuscule cost compared to all the other downstream activities.
 
 _For this reason, it is **much better** to ship with fewer features and only add new features over time as required by customers._
 


### PR DESCRIPTION
## Summary
- fix the "miniscule" typo in the hero scenarios guidance

## Related issue
- N/A (trivial documentation typo fix)

## Guideline alignment
- follows `CONTRIBUTING.md` documentation guidance and targets the `vNext` branch
- keeps the change to a single documentation sentence with no behavior impact

## Validation
- ran `git diff --check`
