### PR TITLE
docs: fix enum guidance typo

### DIFF
--- a/graph/patterns/enums.md
+++ b/graph/patterns/enums.md
@@ -69,7 +69,7 @@ By using an evolvable enum, instead, all we need to do is to add new members:
 </EnumType>
 ```
 
-Similarly speaking, if you find yourself using a `nullable` Enum, that is a indication that maybe what you are trying to model is something that has 3 states and an enum is more appropraite. For instance, let's assume we have a boolean property called `syncEnabled`, where `null` means that the value is undefined and inherited from the general tenant configuration. Instead of modelling like a boolean:
+Similarly speaking, if you find yourself using a `nullable` Enum, that is a indication that maybe what you are trying to model is something that has 3 states and an enum is more appropriate. For instance, let's assume we have a boolean property called `syncEnabled`, where `null` means that the value is undefined and inherited from the general tenant configuration. Instead of modelling like a boolean:
 
 ```xml
 <Property Name="syncEnabled" Type="Edm.Boolean" Nullable="true"/>


### PR DESCRIPTION
## Summary
- fix the "appropraite" typo in the enum modeling guidance

## Related issue
- N/A (trivial documentation typo fix)

## Guideline alignment
- follows `CONTRIBUTING.md` documentation guidance and targets the `vNext` branch
- keeps the change to a single documentation sentence with no behavior impact

## Validation
- ran `git -c core.whitespace=cr-at-eol diff --check`
